### PR TITLE
Add support for validating nested objects.

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -121,7 +121,7 @@ Validator.prototype.validateObject = function (instance, schema, options) {
         } else {
           prop = undefined;
         }
-        this.validate(prop, schema.properties[property], {'propertyName': property});
+        this.validate(prop, schema.properties[property], {'propertyName': property, 'addError': true});
       }
     }
   }

--- a/test/objects.js
+++ b/test/objects.js
@@ -73,5 +73,32 @@ describe('Objects', function () {
 
   });
 
+  describe('nested object with property', function () {
+    it('should NOT validate a valid object', function () {
+      this.validator.validate(
+        {'name': 'test', 'nested': 'test2'},
+        {
+          'type': 'object',
+          'properties': {
+            'name': {'type': 'string'},
+            'nested': {'type': 'object'}
+          }
+        }
+      ).should.not.be.empty;
+    });
+
+    it('should validate a valid object', function () {
+      this.validator.validate(
+        {'name': 'test', 'nested': 'test2'},
+        {
+          'type': 'object',
+          'properties': {
+            'name': {'type': 'string'},
+            'nested': {'type': 'string'}
+          }
+        }
+      ).should.be.empty;
+    });
+  });
 
 });


### PR DESCRIPTION
I've had the problem that

``` js
        {'name': 'test', 'nested': 'test2'},
```

would validate against the schema

``` js
        {
          'type': 'object',
          'properties': {
            'name': {'type': 'string'},
            'nested': {'type': 'object'}
          }
        }
```

which is obviously wrong since `typeof 'test2' !== 'object'`...

My patch fixes it and still passes all other test cases.
