### PR TITLE
There's a bug in the union type check which caused some tests to pass which shouldn't

### DIFF
--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -111,7 +111,7 @@ Attribute.prototype.validate$ref = function () {
   if (helpers.isDefined(this.value) && this.validator.schemas[this.value]) {
     return this.validator.validateSchema(this.instance, this.validator.schemas[this.value], this.options);
   } else {
-    return this.createError("no such schema" + this.value);
+    return this.createError("no such schema " + this.value);
   }
 };
 

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -181,28 +181,27 @@ Validator.prototype.validateArray = function (instance, schema, options) {
 
 Validator.prototype.validateUnionType = function (instance, schema, options) {
   var i, len;
-  var errors = [];
+  var numErrors = this.errors.length;
+  var startingNumErrors = numErrors;
+  var valid = false;
   for (i = 0, len = schema.type.length; i < len; i++) {
     if (typeof schema.type[i] === 'string') {
       this.validateSchema(instance, {'type': schema.type[i]});
     } else {
       this.validateSchema(instance, schema.type[i]);
     }
-
-    if (this.errors.length === 0) {
-      // early exit one element of the union passes the test
-      return;
+    if (this.errors.length === numErrors) {
+      valid = true;
+      break;
     } else {
-      // reset
-      errors = errors.concat(this.errors);
-      this.errors = [];
+      numErrors = this.errors.length - startingNumErrors;
     }
   }
 
-  this.errors = errors;
-
-  if (this.errors.length !== 0) {
-      this.addError("not any of union type");
+  if (valid) {
+    this.errors = this.errors.slice(0, startingNumErrors);
+  } else {
+    this.addError("not any of union type");
   }
 };
 

--- a/test/union.js
+++ b/test/union.js
@@ -113,8 +113,7 @@ describe('Union', function () {
           }
         }
       };
-      var validator = new Validator();
-      validator.validate({'wildcards': ['*']}, schema).should.be.empty;
+      this.validator.validate({'wildcards': ['*']}, schema).should.be.empty;
     });
 
     it('should validate for empty array', function () {
@@ -127,8 +126,7 @@ describe('Union', function () {
           }
         }
       };
-      var validator = new Validator();
-      validator.validate({'wildcards': []}, schema).should.be.empty;
+      this.validator.validate({'wildcards': []}, schema).should.be.empty;
     });
 
     it('should validate for objectid', function () {
@@ -141,8 +139,7 @@ describe('Union', function () {
           }
         }
       };
-      var validator = new Validator();
-      validator.validate({'wildcards': [{"id": "1234", "_bsontype": "test"}, '*']}, schema).should.be.empty;
+      this.validator.validate({'wildcards': [{"id": "1234", "_bsontype": "test"}, '*']}, schema).should.be.empty;
     });
 
     it('should validate for objectid and ignore title and description', function () {
@@ -155,9 +152,50 @@ describe('Union', function () {
           }
         }
       };
-      var validator = new Validator();
-      validator.validate({'wildcards': [{"id": "1234", "_bsontype": "test"}, '*']}, schema).should.be.empty;
+      this.validator.validate({'wildcards': [{"id": "1234", "_bsontype": "test"}, '*']}, schema).should.be.empty;
     });
 
+  });
+
+  describe('union type in nested object array', function () {
+    var schema = {
+      type: 'object',
+      required: true,
+      properties: {
+        frames: {
+          type: 'array',
+          required: true,
+          items: {
+            type: 'object',
+            properties: {
+              filename: {type: 'string', required: true},
+              lineno: {type: ['integer', 'null']},
+              method: {type: ['string', 'null']}
+            }
+          }
+        },
+        exception: {
+          type: 'object',
+          required: true,
+          properties: {
+            class: {type: 'string', required: true},
+            message: {type: 'string'}
+          }
+        }
+      }
+    };
+    var exc = {class: 'testing...', message: 'this is only a test'};
+    it('should validate for nulls', function () {
+      var instance = {frames: [{filename: 'somefile.js', lineno: null}], exception: exc};
+      this.validator.validate(instance, schema).should.be.empty;
+      });
+    it('should validate for null and string', function () {
+      var instance = {frames: [{filename: 'somefile.js', lineno: null}], exception: exc};
+      this.validator.validate(instance, schema).should.be.empty;
+      });
+    it('should not validate for string and string', function () {
+      var instance = {frames: [{filename: 'somefile.js', lineno: {hello: 'world'}}], exception: exc};
+      this.validator.validate(instance, schema).should.not.be.empty;
+      });
   });
 });


### PR DESCRIPTION
This fixes bug in union validation which was throwing away this.errors whenever it found a valid union type. Also, it fixes some of the tests for $ref. They weren't referencing the validator that had the schemas loaded and, I think, were passing the tests because of the union bug.
