### PR TITLE
Conditional assignment of properties to object instance

### DIFF
--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -174,7 +174,7 @@ validators.items = function validateItems (instance, schema, options, ctx) {
       return false;
     }
     var res = self.validateSchema(value, items, options, ctx.makeChild(items, i));
-    if(res.instance !== result.instance[i]) result.instance[i] = res.instance;
+    result.instance[i] = res.instance;
     result.importErrors(res);
     return true;
   });


### PR DESCRIPTION
I've been having issues with using jsonschema with the MongoDB node driver since the refactor to allow values to be updated.  The problem is that the node driver coerces undefined values into null values when creating the BSON document.  The refactored jsonschema code is assigning any properties not already defined in the object instance with the return value of validateSchema.  In other words between jsonschema and MongoDB all unspecified properties were being inserted with a value of null.

I've added inequality checks to the the updates so that if both values are undefined then no assignment occurs and the property will remain undefined in the Mongo BSON document.
