### PR TITLE
Fix enum validation when default attribute exists

### DIFF
--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -561,6 +561,9 @@ validators.enum = function validateEnum (instance, schema) {
   if (!(schema.enum instanceof Array)) {
     throw new SchemaError("enum expects an array", schema);
   }
+  if (instance === undefined) {
+    instance = schema.default;
+  }
   if (!schema.enum.some(helpers.deepCompareStrict.bind(null, instance))) {
     return "is not one of enum values: " + schema.enum;
   }

--- a/test/attributes.js
+++ b/test/attributes.js
@@ -242,6 +242,13 @@ describe('Attributes', function () {
       return this.validator.validate(3, {'type': 'string', 'enum': [1, 2]}).valid.should.be.false;
     });
 
+    it('should validate if value is undefined but defaults to one of the enum values', function () {
+      return this.validator.validate(undefined, {'enum': ['foo', 'bar', 'baz'], 'default': 'baz'}).valid.should.be.true;
+    });
+
+    it('should not validate if value is undefined and required, even if a default is given', function () {
+      return this.validator.validate(undefined, {'enum': ['foo', 'bar', 'baz'], 'required': true, 'default': 'baz'}).valid.should.be.false;
+    });
   });
 
   describe('description', function () {


### PR DESCRIPTION
> This patch allows an undefined instance to validate correctly with the
> “enum” attribute if a “default” attribute is also provided that
> validates with the “enum” attribute.
> 
> An undefined instance with with a “required” attribute of `true` will
> still fail to validate (from the “required” attribute).

So from reading the [spec](http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.19) I wasn't completely sure if inclusion of the `enum` attribute essentially implied that `required: true`. This patch is for the interpretation otherwise.
