### PR TITLE
Fix TypeError when 'properties' are checked against non-object

### DIFF
--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -138,7 +138,7 @@ validators.oneOf = function validateOneOf (instance, schema, options, ctx) {
  * @return {String|null|ValidatorResult}
  */
 validators.properties = function validateProperties (instance, schema, options, ctx) {
-  if(instance === undefined) return;
+  if(instance === undefined || !(instance instanceof Object)) return;
   var result = new ValidatorResult(instance, schema, options, ctx);
   var properties = schema.properties || {};
   for (var property in properties) {

--- a/test/objects.js
+++ b/test/objects.js
@@ -74,6 +74,18 @@ describe('Objects', function () {
       ).valid.should.be.true;
     });
 
+    it('should not throw when checking properties on a non-object', function() {
+      this.validator.validate(
+        null,
+        {
+          'type': 'object',
+          'properties': {
+            'name': {'type': 'string'}
+          }
+        }
+      ).valid.should.be.false;
+    });
+
   });
 
   describe('nested object with property', function () {


### PR DESCRIPTION
If the schema has "properties" and the incoming value is null, the validate function throws a TypeError exception:

TypeError: Cannot read property 'name' of null
      at Validator.validateProperties (/Users/afischer/jsonschema/lib/attribute.js:147:40)
      at Validator.validateSchema (/Users/afischer/jsonschema/lib/validator.js:208:34)
      at Validator.validate (/Users/afischer/jsonschema/lib/validator.js:137:23)
      at Context.it.validator.validate.name (/Users/afischer/jsonschema/test/objects.js:78:22)
      at Test.Runnable.run (/Users/afischer/jsonschema/node_modules/mocha/lib/runnable.js:213:32)
      at Runner.runTest (/Users/afischer/jsonschema/node_modules/mocha/lib/runner.js:344:10)
      at Runner.runTests.next (/Users/afischer/jsonschema/node_modules/mocha/lib/runner.js:390:12)
      at next (/Users/afischer/jsonschema/node_modules/mocha/lib/runner.js:270:14)
      at Runner.hooks (/Users/afischer/jsonschema/node_modules/mocha/lib/runner.js:279:7)
      at next (/Users/afischer/jsonschema/node_modules/mocha/lib/runner.js:227:23)
      at Runner.hook (/Users/afischer/jsonschema/node_modules/mocha/lib/runner.js:247:5)
      at process.startup.processNextTick.process._tickCallback (node.js:244:9)

From looking at the spec here ( http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.2 ), it seems like "properties" should just be ignored for a non-object instance value.

Attached is my attempt at a fix. Thanks
