### PR TITLE
Only validate format if instance value is string

### DIFF
--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -378,7 +378,7 @@ validators.pattern = function validatePattern (instance, schema) {
  * @return {String|null}
  */
 validators.format = function validateFormat (instance, schema, options, ctx) {
-  if (instance === undefined) {
+  if (!(typeof instance === 'string')) {
     return null;
   }
   if (!helpers.isFormat(instance, schema.format)) {


### PR DESCRIPTION
Fixes a bug where validation with a given format failed when the value is not a string (but null). For example, the following schema definition:

``` javascript
"type": ["string", "null"],
"format": "date-time"
```

should match to `null` as well as to a date. The format should only be validated when the value is actually a string. Just like other string-related constraints as minLength, maxLength and so on do.
