### PR TITLE
fix #47 optional enum

### DIFF
--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -562,9 +562,6 @@ validators.enum = function validateEnum (instance, schema) {
     throw new SchemaError("enum expects an array", schema);
   }
   if (instance === undefined) {
-    instance = schema.default;
-  }
-  if (instance === undefined) {
     return null;
   }
   if (!schema.enum.some(helpers.deepCompareStrict.bind(null, instance))) {


### PR DESCRIPTION
Validation of enum type should obey 'required' attribute in schema definition.
