### PR TITLE
Added type check in properties attribute

### DIFF
--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -140,7 +140,8 @@ validators.oneOf = function validateOneOf (instance, schema, options, ctx) {
 validators.properties = function validateProperties (instance, schema, options, ctx) {
   // should only run if instance is an object
     // dont need to do full validation here since that is already done by the type property
-  if('object' !== typeof instance) return;
+    // need to do a truthy check since null is an object type
+  if(!instance || 'object' !== typeof instance) return;
   var result = new ValidatorResult(instance, schema, options, ctx);
   var properties = schema.properties || {};
   for (var property in properties) {


### PR DESCRIPTION
Added type check in properties attribute to only run when the instance is an object.

See http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.2 for more details.
