### PR TITLE
Added "ok()" function to ValidatorResult

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -32,6 +32,9 @@ var ValidatorResult = exports.ValidatorResult = function ValidatorResult(instanc
   this.propertyPath = ctx.propertyPath;
   this.errors = [];
   this.throwError = options && options.throwError;
+
+  var self = this;
+  this.ok = function() { return 0 == self.errors.length; };
 };
 
 ValidatorResult.prototype.addError = function addError(message) {


### PR DESCRIPTION
This library is wonderful.  Thank you for putting it together.

Testing for `(0 == result.errors.length)` is a little wordy.  So I added an `ok()` helper function to `ValidatorResult` so now `result.ok()` will work.  This is handy if all the user cares about is pass or fail.
