### PR TITLE
Add a preValidateProperty hook that allows features like type coercion t...

### DIFF
--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -142,6 +142,10 @@ validators.properties = function validateProperties (instance, schema, options, 
   var result = new ValidatorResult(instance, schema, options, ctx);
   var properties = schema.properties || {};
   for (var property in properties) {
+    if (typeof options.preValidateProperty == 'function') {
+      options.preValidateProperty(instance, property, properties[property], options, ctx);
+    }
+
     var prop = (instance || undefined) && instance[property];
     var res = this.validateSchema(prop, properties[property], options, ctx.makeChild(properties[property], property));
     if(res.instance !== result.instance[property]) result.instance[property] = res.instance;
@@ -165,6 +169,11 @@ function testAdditionalProperty (instance, schema, options, ctx, property, resul
     result.addError("Property " + property + " does not exist in the schema");
   } else {
     var additionalProperties = schema.additionalProperties || {};
+
+    if (typeof options.preValidateProperty == 'function') {
+      options.preValidateProperty(instance, property, additionalProperties, options, ctx);
+    }
+
     var res = this.validateSchema(instance[property], additionalProperties, options, ctx.makeChild(additionalProperties, property));
     if(res.instance !== result.instance[property]) result.instance[property] = res.instance;
     result.importErrors(res);
@@ -193,6 +202,11 @@ validators.patternProperties = function validatePatternProperties (instance, sch
         continue;
       }
       test = false;
+
+      if (typeof options.preValidateProperty == 'function') {
+        options.preValidateProperty(instance, property, patternProperties[pattern], options, ctx);
+      }
+
       var res = this.validateSchema(instance[property], patternProperties[pattern], options, ctx.makeChild(patternProperties[pattern], property));
       if(res.instance !== result.instance[property]) result.instance[property] = res.instance;
       result.importErrors(res);


### PR DESCRIPTION
...o be implemented by users of the module.

I'm currently implementing request & response validation using jsonschema for hapi. A problem I hit was the strict type-checking of jsonschema. I realise that this is a good thing in itself, but to be able to use schemas for query strings and path segments I needed some type coercion. As this isn't something that should be done in the jsonschema module I propose that we add the possibility to hook in before property validation using a function on the options object.

In the case of my module I would then simply provide a preValidateProperty function like this:

``` javascript
function (instance, property, schema, options, ctx) {
  var value = instance[property];

  // Skip nulls and undefineds
  if (value === null || typeof value == 'undefined') {
    return;
  }

  // If the schema declares a type and the property fails type validation.
  if (schema.type && this.attributes.type.call(this, instance, schema, options, ctx.makeChild(schema, property))) {
    var types = (schema.type instanceof Array) ? schema.type : [schema.type];
    var coerced = undefined;

    // Go through the declared types until we find something that we can
    // coerce the value into.
    for (var i = 0; typeof coerced == 'undefined' && i < types.length; i++) {
      // If we support coercion to this type
      if (lib.coercions[types[i]]) {
        // ...attempt it.
        coerced = lib.coercions[types[i]](value);
      }
    }
    // If we got a successful coercion we modify the property of the instance.
    if (typeof coerced != 'undefined') {
      instance[property] = coerced;
    }
  }
}.bind(validator)
```

...that takes care of all the ugliness.
