### PR TITLE
Use Array.isArray(...) instead of instanceof Array

### DIFF
--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -43,7 +43,7 @@ validators.type = function validateType (instance, schema, options, ctx) {
   if (instance === undefined) {
     return null;
   }
-  var types = (schema.type instanceof Array) ? schema.type : [schema.type];
+  var types = Array.isArray(schema.type) ? schema.type : [schema.type];
   if (!types.some(this.testType.bind(this, instance, schema, options, ctx))) {
     return "is not of a type(s) " + types.map(function (v) {
       return v.id && ('<' + v.id + '>') || (v+'');
@@ -69,7 +69,7 @@ validators.anyOf = function validateAnyOf (instance, schema, options, ctx) {
   if (instance === undefined) {
     return null;
   }
-  if (!(schema.anyOf instanceof Array)){
+  if (!Array.isArray(schema.anyOf)){
     throw new SchemaError("anyOf must be an array");
   }
   if (!schema.anyOf.some(testSchema.bind(this, instance, options, ctx))) {
@@ -93,7 +93,7 @@ validators.allOf = function validateAllOf (instance, schema, options, ctx) {
   if (instance === undefined) {
     return null;
   }
-  if (!(schema.allOf instanceof Array)){
+  if (!Array.isArray(schema.allOf)){
     throw new SchemaError("allOf must be an array");
   }
   if (!schema.allOf.every(testSchema.bind(this, instance, options, ctx))) {
@@ -117,7 +117,7 @@ validators.oneOf = function validateOneOf (instance, schema, options, ctx) {
   if (instance === undefined) {
     return null;
   }
-  if (!(schema.oneOf instanceof Array)){
+  if (!Array.isArray(schema.oneOf)){
     throw new SchemaError("oneOf must be an array");
   }
   var count = schema.oneOf.filter(testSchema.bind(this, instance, options, ctx)).length;
@@ -270,7 +270,7 @@ validators.maxProperties = function validateMaxProperties (instance, schema) {
  * @return {String|null|ValidatorResult}
  */
 validators.items = function validateItems (instance, schema, options, ctx) {
-  if (!(instance instanceof Array)) {
+  if (!Array.isArray(instance)) {
     return null;
   }
   var self = this;
@@ -279,7 +279,7 @@ validators.items = function validateItems (instance, schema, options, ctx) {
     return result;
   }
   instance.every(function (value, i) {
-    var items = (schema.items instanceof Array) ? (schema.items[i] || schema.additionalItems) : schema.items;
+    var items = Array.isArray(schema.items) ? (schema.items[i] || schema.additionalItems) : schema.items;
     if (items === undefined) {
       return true;
     }
@@ -491,7 +491,7 @@ validators.maxLength = function validateMaxLength (instance, schema) {
  * @return {String|null}
  */
 validators.minItems = function validateMinItems (instance, schema) {
-  if (!(instance instanceof Array)) {
+  if (!Array.isArray(instance) {
     return null;
   }
   if (!(instance.length >= schema.minItems)) {
@@ -507,7 +507,7 @@ validators.minItems = function validateMinItems (instance, schema) {
  * @return {String|null}
  */
 validators.maxItems = function validateMaxItems (instance, schema) {
-  if (!(instance instanceof Array)) {
+  if (!Array.isArray(instance)) {
     return null;
   }
   if (!(instance.length <= schema.maxItems)) {
@@ -526,7 +526,7 @@ validators.maxItems = function validateMaxItems (instance, schema) {
  */
 validators.uniqueItems = function validateUniqueItems (instance, schema, options, ctx) {
   var result = new ValidatorResult(instance, schema, options, ctx);
-  if (!(instance instanceof Array)) {
+  if (!Array.isArray(instance)) {
     return result;
   }
   function testArrays (v, i, a) {
@@ -565,7 +565,7 @@ function testArrays (v, i, a) {
  * @return {String|null}
  */
 validators.uniqueItems = function validateUniqueItems (instance) {
-  if (!(instance instanceof Array)) {
+  if (!Array.isArray(instance)) {
     return null;
   }
 
@@ -597,7 +597,7 @@ validators.dependencies = function validateDependencies (instance, schema, optio
     if (typeof dep == 'string') {
       dep = [dep];
     }
-    if (dep instanceof Array) {
+    if (Array.isArray(dep)) {
       dep.forEach(function (prop) {
         if (instance[prop] === undefined) {
           result.addError("property " + prop + " not found, required by " + childContext.propertyPath);
@@ -623,7 +623,7 @@ validators.dependencies = function validateDependencies (instance, schema, optio
  * @return {String|null}
  */
 validators.enum = function validateEnum (instance, schema) {
-  if (!(schema.enum instanceof Array)) {
+  if (!Array.isArray(schema.enum)) {
     throw new SchemaError("enum expects an array", schema);
   }
   if (instance === undefined) {
@@ -649,7 +649,7 @@ validators.not = validators.disallow = function validateNot (instance, schema, o
   var result = new ValidatorResult(instance, schema, options, ctx);
   var notTypes = schema.not || schema.disallow;
   if(!notTypes) return null;
-  if(!(notTypes instanceof Array)) notTypes=[notTypes];
+  if(!Array.isArray(notTypes)) notTypes=[notTypes];
   notTypes.forEach(function (type) {
     if (self.testType(instance, schema, options, ctx, type)) {
       var schemaId = type && type.id && ('<' + type.id + '>') || type;

--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -491,7 +491,7 @@ validators.maxLength = function validateMaxLength (instance, schema) {
  * @return {String|null}
  */
 validators.minItems = function validateMinItems (instance, schema) {
-  if (!Array.isArray(instance) {
+  if (!Array.isArray(instance)) {
     return null;
   }
   if (!(instance.length >= schema.minItems)) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -166,8 +166,8 @@ exports.deepCompareStrict = function deepCompareStrict (a, b) {
   if (typeof a !== typeof b) {
     return false;
   }
-  if (a instanceof Array) {
-    if (!(b instanceof Array)) {
+  if (Array.isArray(a)) {
+    if (!Array.isArray(b)) {
       return false;
     }
     if (a.length !== b.length) {

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -71,7 +71,7 @@ Validator.prototype.addSubSchema = function addSubSchema(baseuri, schema) {
     var documentUri = ourUri.replace(/^([^#]*)#$/, '$1');
     this.schemas[documentUri] = schema;
   }
-  this.addSubSchemaArray(ourBase, ((schema.items instanceof Array)?schema.items:[schema.items]));
+  this.addSubSchemaArray(ourBase, (Array.isArray(schema.items)?schema.items:[schema.items]));
   this.addSubSchema(ourBase, schema.additionalItems);
   this.addSubSchemaObject(ourBase, schema.properties);
   this.addSubSchema(ourBase, schema.additionalProperties);
@@ -87,7 +87,7 @@ Validator.prototype.addSubSchema = function addSubSchema(baseuri, schema) {
 };
 
 Validator.prototype.addSubSchemaArray = function addSubSchemaArray(baseuri, schemas) {
-  if(!(schemas instanceof Array)) return;
+  if(!Array.isArray(schemas)) return;
   for(var i=0; i<schemas.length; i++){
     this.addSubSchema(baseuri, schemas[i]);
   }
@@ -188,7 +188,7 @@ Validator.prototype.validateSchema = function validateSchema (instance, schema, 
   }
 
   if (schema.extends) {
-    if (schema.extends instanceof Array) {
+    if (Array.isArray(schema.extends)) {
       schema.extends.forEach(function (s) {
         schema = helpers.deepMerge(schema, resolve(s, ctx));
       });
@@ -295,7 +295,7 @@ types.number = function testNumber (instance) {
   return typeof instance == 'number';
 };
 types.array = function testArray (instance) {
-  return instance instanceof Array;
+  return Array.isArray(instance);
 };
 types.null = function testNull (instance) {
   return instance === null;
@@ -308,7 +308,7 @@ types.any = function testAny (instance) {
 };
 types.object = function testObject (instance) {
   // TODO: fix this - see #15
-  return instance && (typeof instance) === 'object' && !(instance instanceof Array) && !(instance instanceof Date);
+  return instance && (typeof instance) === 'object' && !Array.isArray(instance) && !(instance instanceof Date);
 };
 
 module.exports = Validator;


### PR DESCRIPTION
We want to perform JSON schema validation on our project, but the validation fails on instanceof Array checks. The reasons for using Array.isArray(...) are given in the article:

http://web.mit.edu/jwalden/www/isArray.html

Changing all array instance checks to use Array.isArray(...) fixes our issues, and may well help others who want to use this library.
