### PR TITLE
New `filter` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,10 @@ All types are supported
 All formats are supported, phone numbers are expected to follow the [http://en.wikipedia.org/wiki/E.123](E.123) standard.
 
 ### Results
-The first error found will be thrown as an `Error` object if `options.throwError` is `true`.  Otherwise all results will be appended to the `result.errors` array which also contains the success flag `result.valid`.
+The first error found will be thrown as an `Error` object if `options.throwError` is `true`. Otherwise all results will be appended to the `result.errors` array which also contains the success flag `result.valid`.
 
 ### Filter
-Filter away any properties not in schema if `options.filter` is `true` and  `options.additionalProperties` is `false`. By default: `false`
+Filter away any properties not in schema if `options.filter` is `true` and `options.additionalProperties` is `false`. By default: `false`.
 
 ### Custom properties
 Specify your own JSON Schema properties with the validator.attributes property:

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ All formats are supported, phone numbers are expected to follow the [http://en.w
 ### Results
 The first error found will be thrown as an `Error` object if `options.throwError` is `true`.  Otherwise all results will be appended to the `result.errors` array which also contains the success flag `result.valid`.
 
+### Filter
+Filter away any properties not in schema if `options.filter` is `true` and  `options.additionalProperties` is `false`. By default: `false`
+
 ### Custom properties
 Specify your own JSON Schema properties with the validator.attributes property:
 

--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -53,7 +53,7 @@ validators.type = function validateType (instance, schema, options, ctx) {
 };
 
 function testSchema(instance, options, ctx, schema){
-	return this.validateSchema(instance, schema, options, ctx).valid;
+  return this.validateSchema(instance, schema, options, ctx).valid;
 }
 
 /**
@@ -162,7 +162,11 @@ function testAdditionalProperty (instance, schema, options, ctx, property, resul
     return;
   }
   if (schema.additionalProperties === false) {
-    result.addError("Property " + property + " does not exist in the schema");
+    if (options.filter) {
+      delete instance[property];
+    } else {
+      result.addError("Property " + property + " does not exist in the schema");
+    }
   } else {
     var additionalProperties = schema.additionalProperties || {};
     var res = this.validateSchema(instance[property], additionalProperties, options, ctx.makeChild(additionalProperties, property));

--- a/test/objects.js
+++ b/test/objects.js
@@ -195,4 +195,63 @@ describe('Objects', function () {
       ).valid.should.be.false;
     });
   });
+
+  describe('validate with filter', function () {
+    var schema = {
+      description: "Simple object",
+        required: true,
+        type: "object",
+        additionalProperties: false,
+        properties:{
+        a: {
+          type: "number",
+            required: true
+        },
+        b: {
+          type: "string",
+            required: false,
+            readonly: true
+        }
+      }
+    };
+
+    describe('simple schema validation without filter: true', function () {
+      var result;
+      var document = {a: 1, c: 'd', notInSchemaField: 'foo'};
+
+      before(function () {
+        result = this.validator.validate(document, schema);
+      });
+
+      it('should not validate', function () {
+        result.should.have.property("valid", false);
+      });
+
+      it('should provide errors', function () {
+        console.log(result);
+        result.errors.should.not.deep.equal([]);
+      });
+    });
+
+    describe('simple schema validation with filter: true', function () {
+      var result;
+      var document = {a: 1, c: 'd', thisIsNotInSchemaField: 'foo'};
+
+      before(function () {
+        result = this.validator.validate(document, schema, {filter: true});
+      });
+
+      it('should validate', function () {
+        result.should.have.property("valid", true);
+      });
+
+      it('should remove properties that are not in schema', function () {
+        document.should.not.have.property("thisIsNotInSchemaField");
+      });
+
+      it('should have no errors', function () {
+        result.errors.should.deep.equal([]);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Allows to filter away any properties not in schema if `options.filter` is `true` and `options.additionalProperties` is `false`. By default: `false`.