### PR TITLE
Optional 'schema' and 'instance' in validation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@ All types are supported
 All formats are supported, phone numbers are expected to follow the [http://en.wikipedia.org/wiki/E.123](E.123) standard.
 
 ### Results
-The first error found will be thrown as an `Error` object if `options.throwError` is `true`.  Otherwise all results will be appended to the `result.errors` array which also contains the success flag `result.valid`.
+The first error found will be thrown as an `Error` object if `options.throwError` is `true`. Otherwise all results will be appended to the `result.errors` array which also contains the success flag `result.valid`.
+
+If you want to exclude `instance` or `schema` from error you can use `options.includeInstance: false` and `options.includeSchema: false`. Useful when your schema or instance is too big or schema is documented somewhere else.
 
 ### Custom properties
 Specify your own JSON Schema properties with the validator.attributes property:

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -27,12 +27,8 @@ ValidationError.prototype.toString = function toString() {
 };
 
 var ValidatorResult = exports.ValidatorResult = function ValidatorResult(instance, schema, options, ctx) {
-  if (options.includeInstance !== false) {
-    this.instance = instance;
-  }
-  if (options.includeSchema !== false) {
-    this.schema = schema;
-  }
+  this.instance = (options.includeInstance === false) ? {} :  instance;
+  this.schema = (options.includeSchema) === false ? {} : schema;
   this.propertyPath = ctx.propertyPath;
   this.errors = [];
   this.throwError = options && options.throwError;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -27,8 +27,12 @@ ValidationError.prototype.toString = function toString() {
 };
 
 var ValidatorResult = exports.ValidatorResult = function ValidatorResult(instance, schema, options, ctx) {
-  this.instance = instance;
-  this.schema = schema;
+  if (options.includeInstance !== false) {
+    this.instance = instance;
+  }
+  if (options.includeSchema !== false) {
+    this.schema = schema;
+  }
   this.propertyPath = ctx.propertyPath;
   this.errors = [];
   this.throwError = options && options.throwError;

--- a/test/options.js
+++ b/test/options.js
@@ -20,14 +20,14 @@ describe('Options', function () {
 	});
 
 	describe('validate with option includeInstance = false', function () {
-		it('should provide instance', function () {
-			this.validator.validate(4, {"type": "string"}, {includeInstance: false}).errors.should.not.have.deep.property('0.instance');
+		it('should not provide empty instance', function () {
+			this.validator.validate(4, {"type": "string"}, {includeInstance: false}).errors.should.have.deep.property('0.instance').to.deep.eql({});
 		});
 	});
 
 	describe('validate with option includeSchema = false', function () {
-		it('should provide instance', function () {
-			this.validator.validate(4, {"type": "string"}, {includeSchema: false}).errors.should.not.have.deep.property('0.schema');
+		it('should provide empty schema', function () {
+			this.validator.validate(4, {"type": "string"}, {includeSchema: false}).errors.should.have.deep.property('0.schema').to.deep.eql({});
 		});
 	});
 });

--- a/test/options.js
+++ b/test/options.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var Validator = require('../lib/validator');
+require('chai').should();
+
+describe('Options', function () {
+
+	beforeEach(function () {
+		this.validator = new Validator();
+	});
+
+	describe('validate without options', function () {
+		it('should provide instance', function () {
+			this.validator.validate(4, {"type": "string"}).errors.should.have.deep.property('0.instance', 4);
+		});
+
+		it('should provide schema', function () {
+			this.validator.validate(4, {"type": "string"}).errors.should.have.deep.property('0.schema');
+		});
+	});
+
+	describe('validate with option includeInstance = false', function () {
+		it('should provide instance', function () {
+			this.validator.validate(4, {"type": "string"}, {includeInstance: false}).errors.should.not.have.deep.property('0.instance');
+		});
+	});
+
+	describe('validate with option includeSchema = false', function () {
+		it('should provide instance', function () {
+			this.validator.validate(4, {"type": "string"}, {includeSchema: false}).errors.should.not.have.deep.property('0.schema');
+		});
+	});
+});


### PR DESCRIPTION
Sometimes schema or instance is too big for outputing it in the error. New options allows you to exclude them from error.