### PR TITLE
update date-time format so that it is more conformant with RFC 3339

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -101,7 +101,7 @@ SchemaContext.prototype.makeChild = function makeChild(schema, propertyName){
 }
 
 var FORMAT_REGEXPS = exports.FORMAT_REGEXPS = {
-  'date-time': /^\d{4}-(?:0[0-9]{1}|1[0-2]{1})-[0-9]{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?Z$/,
+  'date-time': /^\d{4}-(?:0[0-9]{1}|1[0-2]{1})-[0-9]{2}[tT ]\d{2}:\d{2}:\d{2}(\.\d+)?([zZ]|[+-]\d{2}:\d{2})$/,
   'date': /^\d{4}-(?:0[0-9]{1}|1[0-2]{1})-[0-9]{2}$/,
   'time': /^\d{2}:\d{2}:\d{2}$/,
 

--- a/test/formats.js
+++ b/test/formats.js
@@ -20,12 +20,35 @@ describe('Formats', function () {
       this.validator.validate("2012-07-08T16:41:41Z", {'type': 'string', 'format': 'date-time'}).valid.should.be.true;
     });
 
+    it('should validate a date-time with a timezone offset instead of Z', function () {
+        this.validator.validate("2012-07-08T16:41:41.532+00:00", {'type': 'string', 'format': 'date-time'}).valid.should.be.true;
+        this.validator.validate("2012-07-08T16:41:41.532+05:30", {'type': 'string', 'format': 'date-time'}).valid.should.be.true;
+        this.validator.validate("2012-07-08T16:41:41.532+04:00", {'type': 'string', 'format': 'date-time'}).valid.should.be.true;
+    });
+
+    it('should validate a date-time with a z instead of a Z', function () {
+        this.validator.validate("2012-07-08T16:41:41.532z", {'type': 'string', 'format': 'date-time'}).valid.should.be.true;
+    });
+
+    it('should validate a date-time with a space instead of a T', function () {
+        this.validator.validate("2012-07-08 16:41:41.532Z", {'type': 'string', 'format': 'date-time'}).valid.should.be.true;
+    });
+
+    it('should validate a date-time with a t instead of a T', function () {
+        this.validator.validate("2012-07-08t16:41:41.532Z", {'type': 'string', 'format': 'date-time'}).valid.should.be.true;
+    });
+
     it('should not validate a date-time with the time missing', function () {
       this.validator.validate("2012-07-08", {'type': 'string', 'format': 'date-time'}).valid.should.be.false;
     });
 
     it('should not validate an invalid date-time', function () {
       this.validator.validate("TEST2012-07-08T16:41:41.532Z", {'type': 'string', 'format': 'date-time'}).valid.should.be.false;
+    });
+
+    it('should not validate a date-time with a timezone offset AND a Z', function () {
+        this.validator.validate("2012-07-08T16:41:41.532+00:00Z", {'type': 'string', 'format': 'date-time'}).valid.should.be.false;
+        this.validator.validate("2012-07-08T16:41:41.532+Z00:00", {'type': 'string', 'format': 'date-time'}).valid.should.be.false;
     });
   });
 


### PR DESCRIPTION
based on the grammar and note here: http://tools.ietf.org/html/rfc3339#section-5.6
- the existing regex does not allow for a time offset
- the existing regex does not allow for a lowercase 't' or lowercase 'z'
- the existing regex does not allow for a space character instead of a
  'T', as described in the note
- the existing regex does not allow arbitrarily many digits in the
  second fraction part
