### PR TITLE
Display errors from oneOf, anyOf, allOf subschema validations

### DIFF
--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -52,10 +52,6 @@ validators.type = function validateType (instance, schema, options, ctx) {
   return null;
 };
 
-function testSchema(instance, options, ctx, schema){
-	return this.validateSchema(instance, schema, options, ctx).valid;
-}
-
 /**
  * Validates whether the instance matches some of the given schemas
  * @param instance
@@ -72,12 +68,17 @@ validators.anyOf = function validateAnyOf (instance, schema, options, ctx) {
   if (!(schema.anyOf instanceof Array)){
     throw new SchemaError("anyOf must be an array");
   }
-  if (!schema.anyOf.some(testSchema.bind(this, instance, options, ctx))) {
-    return "is not any of " + schema.anyOf.map(function (v) {
-      return v.id && ('<' + v.id + '>') || (v+'');
-    });
+  var errors = {};
+  for (var i in schema.anyOf) {
+	var res = this.validateSchema(instance, schema.anyOf[i], options, ctx);
+    if (res.valid)
+      return null;
+    errors['schema['+i+']'] = res.errors;
   }
-  return null;
+  return new helpers.ValidationError("is not any of " +
+      schema.anyOf.map(function (v) {
+        return v.id ? ('<' + v.id + '>') : JSON.stringify(v);
+      }), instance, schema, ctx.propertyPath, errors);
 };
 
 /**
@@ -96,10 +97,16 @@ validators.allOf = function validateAllOf (instance, schema, options, ctx) {
   if (!(schema.allOf instanceof Array)){
     throw new SchemaError("allOf must be an array");
   }
-  if (!schema.allOf.every(testSchema.bind(this, instance, options, ctx))) {
-    return "is not all from " + schema.allOf.map(function (v) {
-      return v.id && ('<' + v.id + '>') || (v+'');
-    });
+  var errors = {};
+  for (var i in schema.allOf) {
+	var res = this.validateSchema(instance, schema.allOf[i], options, ctx);
+    if (!res.valid) {
+      errors['schema['+i+']'] = res.errors;
+      return new helpers.ValidationError("is not all from " +
+          schema.allOf.map(function (v) {
+            return v.id ? ('<' + v.id + '>') : JSON.stringify(v);
+          }), instance, schema, ctx.propertyPath, errors);
+    }
   }
   return null;
 };
@@ -120,11 +127,18 @@ validators.oneOf = function validateOneOf (instance, schema, options, ctx) {
   if (!(schema.oneOf instanceof Array)){
     throw new SchemaError("oneOf must be an array");
   }
-  var count = schema.oneOf.filter(testSchema.bind(this, instance, options, ctx)).length;
-  if (count!==1) {
-    return "is not exactly one from " + schema.oneOf.map(function (v) {
-      return v.id && ('<' + v.id + '>') || (v+'');
-    });
+  var errors = {};
+  for (var i in schema.oneOf) {
+    var v = schema.oneOf[i];
+	var res = this.validateSchema(instance, v, options, ctx);
+    if (!res.valid)
+        errors['schema['+i+']'] = res.errors;
+  }
+  if (schema.oneOf.length - 1 !== Object.keys(errors).length) {
+    return new helpers.ValidationError("is not exactly one from " +
+        schema.oneOf.map(function (v) {
+          return v.id ? ('<' + v.id + '>') : JSON.stringify(v);
+        }), instance, schema, ctx.propertyPath, errors);
   }
   return null;
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -2,7 +2,7 @@
 
 var uri = require('url');
 
-var ValidationError = exports.ValidationError = function ValidationError (message, instance, schema, propertyPath) {
+var ValidationError = exports.ValidationError = function ValidationError (message, instance, schema, propertyPath, subErrors) {
   if (propertyPath) {
     this.property = propertyPath;
   }
@@ -18,6 +18,9 @@ var ValidationError = exports.ValidationError = function ValidationError (messag
   }
   if (instance) {
     this.instance = instance;
+  }
+  if (subErrors) {
+    this.subErrors = subErrors;
   }
   this.stack = this.toString();
 };
@@ -46,6 +49,8 @@ ValidatorResult.prototype.addError = function addError(message) {
 ValidatorResult.prototype.importErrors = function importErrors(res) {
   if (typeof res == 'string') {
     this.addError(res);
+  } else if (res instanceof ValidationError) {
+    this.errors.push(res);
   } else if (res && res.errors) {
     var errs = this.errors;
     res.errors.forEach(function (v) {
@@ -55,7 +60,20 @@ ValidatorResult.prototype.importErrors = function importErrors(res) {
 };
 
 ValidatorResult.prototype.toString = function toString(res) {
-  return this.errors.map(function(v,i){ return i+': '+v.toString()+'\n'; }).join('');
+
+  function stringifyErrors(errors, prefix) {
+    return errors.map(function(v, i) {
+      var str = prefix + i + ': ' + v.toString() + '\n';
+      if (v.subErrors) {
+        for (var s in v.subErrors) {
+          str += stringifyErrors(v.subErrors[s], prefix + i + '.' + s + '.');
+        }
+      }
+      return str;
+    }).join('');
+  }
+
+  return stringifyErrors(this.errors, '');
 };
 
 Object.defineProperty(ValidatorResult.prototype, "valid", { get: function() {


### PR DESCRIPTION
When oneOf, anyOf, allOf are validated the error messages are mostly useless for finding the root cause of the problem. Invalid data usually results in following message:
```
  request is not exactly one from [object Object],[object Object]
```
no idea what could be wrong (especially if object definitions are complex). I have enhanced jsonschema to keep track of so-called sub-errors (errors encountered when trying to validate data against members of anyOf,oneOf,allOf array members) and display them in error messages. Here is a sample of the new output:

```
0: instance is not any of {"type":"null"},{"anyOf":[{"type":"object","properties":{"attr1":{"required":true,"type":"string"},"attr":{"required":true,"type":"number"}}},{"type":"string"}]}
0.schema[0].0: instance is not of a type(s) null
0.schema[1].0: instance is not any of {"type":"object","properties":{"attr1":{"required":true,"type":"string"},"attr":{"required":true,"type":"number"}}},{"type":"string"}
0.schema[1].0.schema[0].0: instance.attr1 is not of a type(s) string
0.schema[1].0.schema[0].1: instance.attr is required
0.schema[1].0.schema[1].0: instance is not of a type(s) string
```

While the ouput isn't easy to read, it gives you actually all information you need to localize the problem. Just for the record following schema and data were used for generating the message above:

```
js = require('jsonschema');
schema = { anyOf: [{type: 'null'}, {anyOf: [{type: 'object', properties: { attr1: { required: true, type: 'string' }, attr: { required: true, type: 'number'}}}, {type: 'string'}]}] };
var res = js.validate({attr1: 3}, schema);
console.log(res.toString());
```
