### PR TITLE
Improved allOf, anyOf, oneOf errors

### DIFF
--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -74,7 +74,7 @@ validators.anyOf = function validateAnyOf (instance, schema, options, ctx) {
   }
   if (!schema.anyOf.some(testSchema.bind(this, instance, options, ctx))) {
     return "is not any of " + schema.anyOf.map(function (v) {
-      return v.id && ('<' + v.id + '>') || (v+'');
+      return (v.id && ('<' + v.id + '>')) || (v.title && ('<' + v.title + '>')) || (v['$ref'] && ('<' + v['$ref'] + '>')) || '<subschema>';
     });
   }
   return null;
@@ -98,7 +98,7 @@ validators.allOf = function validateAllOf (instance, schema, options, ctx) {
   }
   if (!schema.allOf.every(testSchema.bind(this, instance, options, ctx))) {
     return "is not all from " + schema.allOf.map(function (v) {
-      return v.id && ('<' + v.id + '>') || (v+'');
+      return (v.id && ('<' + v.id + '>')) || (v.title && ('<' + v.title + '>')) || (v['$ref'] && ('<' + v['$ref'] + '>')) || '<subschema>';
     });
   }
   return null;
@@ -123,7 +123,7 @@ validators.oneOf = function validateOneOf (instance, schema, options, ctx) {
   var count = schema.oneOf.filter(testSchema.bind(this, instance, options, ctx)).length;
   if (count!==1) {
     return "is not exactly one from " + schema.oneOf.map(function (v) {
-      return v.id && ('<' + v.id + '>') || (v+'');
+      return (v.id && ('<' + v.id + '>')) || (v.title && ('<' + v.title + '>')) || (v['$ref'] && ('<' + v['$ref'] + '>')) || '<subschema>';
     });
   }
   return null;


### PR DESCRIPTION
When ids are not present in subschemas referenced by `allOf`, `anyOf` and `oneOf`, the errors display `'[object Object]'` in place of the id.  e.g. `'is not any of [object Object],[object Object]'`

This change modifies the error output to use `id`, falling back to `title`, then `$ref`, and if none are present it uses `'<subschema>'`.