### PR TITLE
Display errors from oneOf, anyOf subschema validations if requested

### DIFF
--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -79,16 +79,23 @@ validators.anyOf = function validateAnyOf (instance, schema, options, ctx) {
   if (!Array.isArray(schema.anyOf)){
     throw new SchemaError("anyOf must be an array");
   }
-  if (!schema.anyOf.some(testSchema.bind(this, instance, options, ctx))) {
-    var list = schema.anyOf.map(function (v, i) {
-      return (v.id && ('<' + v.id + '>')) || (v.title && JSON.stringify(v.title)) || (v['$ref'] && ('<' + v['$ref'] + '>')) || '[subschema '+i+']';
-    });
-    result.addError({
-      name: 'anyOf',
-      argument: list,
-      message: "is not any of " + list.join(','),
-    });
+  var errors = {};
+  for (var i in schema.anyOf) {
+    var v = schema.anyOf[i];
+    var res = this.validateSchema(instance, v, options, ctx);
+    if (res.valid)
+      return result;
+    var schemaId = (v.id && ('<' + v.id + '>')) ||
+        (v.title && JSON.stringify(v.title)) ||
+        (v['$ref'] && ('<' + v['$ref'] + '>')) || '[subschema '+i+']';
+    errors[schemaId] = res.errors;
   }
+  result.addError({
+    name: 'anyOf',
+    argument: Object.keys(errors),
+    message: "is not any of " + Object.keys(errors).join(','),
+    subErrors: errors
+  });
   return result;
 };
 
@@ -142,17 +149,30 @@ validators.oneOf = function validateOneOf (instance, schema, options, ctx) {
     throw new SchemaError("oneOf must be an array");
   }
   var result = new ValidatorResult(instance, schema, options, ctx);
-  var count = schema.oneOf.filter(testSchema.bind(this, instance, options, ctx)).length;
-  var list = schema.oneOf.map(function (v, i) {
-    return (v.id && ('<' + v.id + '>')) || (v.title && JSON.stringify(v.title)) || (v['$ref'] && ('<' + v['$ref'] + '>')) || '[subschema '+i+']';
-  });
-  if (count!==1) {
+  var errors = {};
+  var allSchemaIds = [];
+
+  for (var i in schema.oneOf) {
+    var v = schema.oneOf[i];
+    var res = this.validateSchema(instance, v, options, ctx);
+    var schemaId = (v.id && ('<' + v.id + '>')) ||
+        (v.title && JSON.stringify(v.title)) ||
+        (v['$ref'] && ('<' + v['$ref'] + '>')) || '[subschema '+i+']';
+    allSchemaIds.push(schemaId);
+    if (!res.valid) {
+      errors[schemaId] = res.errors;
+    }
+  }
+
+  if (schema.oneOf.length - 1 !== Object.keys(errors).length) {
     result.addError({
       name: 'oneOf',
-      argument: list,
-      message: "is not exactly one from " + list.join(','),
+      argument: allSchemaIds,
+      message: "is not exactly one from " + allSchemaIds.join(','),
+      subErrors: errors
     });
   }
+
   return result;
 };
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -2,7 +2,7 @@
 
 var uri = require('url');
 
-var ValidationError = exports.ValidationError = function ValidationError (message, instance, schema, propertyPath, name, argument) {
+var ValidationError = exports.ValidationError = function ValidationError (message, instance, schema, propertyPath, name, argument, subErrors) {
   if (propertyPath) {
     this.property = propertyPath;
   }
@@ -18,6 +18,9 @@ var ValidationError = exports.ValidationError = function ValidationError (messag
   }
   if (instance) {
     this.instance = instance;
+  }
+  if (subErrors) {
+      this.subErrors = subErrors;
   }
   this.name = name;
   this.argument = argument;
@@ -35,6 +38,7 @@ var ValidatorResult = exports.ValidatorResult = function ValidatorResult(instanc
   this.errors = [];
   this.throwError = options && options.throwError;
   this.disableFormat = options && options.disableFormat === true;
+  this.subSchemaErrors = options && options.subSchemaErrors;
 };
 
 ValidatorResult.prototype.addError = function addError(detail) {
@@ -45,7 +49,7 @@ ValidatorResult.prototype.addError = function addError(detail) {
     if (!detail) throw new Error('Missing error detail');
     if (!detail.message) throw new Error('Missing error message');
     if (!detail.name) throw new Error('Missing validator type');
-    err = new ValidationError(detail.message, this.instance, this.schema, this.propertyPath, detail.name, detail.argument);
+    err = new ValidationError(detail.message, this.instance, this.schema, this.propertyPath, detail.name, detail.argument, detail.subErrors);
   }
 
   if (this.throwError) {
@@ -58,16 +62,30 @@ ValidatorResult.prototype.addError = function addError(detail) {
 ValidatorResult.prototype.importErrors = function importErrors(res) {
   if (typeof res == 'string' || (res && res.validatorType)) {
     this.addError(res);
+  } else if (res instanceof ValidationError) {
+    this.errors.push(res);
   } else if (res && res.errors) {
     Array.prototype.push.apply(this.errors, res.errors);
   }
 };
 
-function stringizer (v,i){
-  return i+': '+v.toString()+'\n';
-}
 ValidatorResult.prototype.toString = function toString(res) {
-  return this.errors.map(stringizer).join('');
+
+  function stringifyErrors(errors, recursive, prefix) {
+    return errors.map(function(v, i) {
+      var str = prefix + i + ': ' + v.toString() + '\n';
+      if (recursive && v.subErrors) {
+        for (var s in v.subErrors) {
+          if (v.subErrors[s])
+            str += stringifyErrors(v.subErrors[s], recursive,
+                prefix + i + '.' + s + '.');
+        }
+      }
+      return str;
+    }).join('');
+  }
+
+  return stringifyErrors(this.errors, this.subSchemaErrors, '');
 };
 
 Object.defineProperty(ValidatorResult.prototype, "valid", { get: function() {


### PR DESCRIPTION
New flag subSchemaErrors in options can be set to true to display sub-errors when converting validation result object to string. This fix preserves all other enhancements done in this area by other recent commits. For more background info see https://github.com/tdegrunt/jsonschema/pull/92
