### PR TITLE
Added 'clean' option to remove undeclared properties from objects

### DIFF
--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -144,7 +144,9 @@ validators.oneOf = function validateOneOf (instance, schema, options, ctx) {
  */
 validators.properties = function validateProperties (instance, schema, options, ctx) {
   if(instance === undefined || !(instance instanceof Object)) return;
-  var result = new ValidatorResult(instance, schema, options, ctx);
+  // With `clean` option set we want to create a copy of the instance in the result to ensure that the original
+  // object is not modified and only defined properties are in the resulting instance.
+  var result = new ValidatorResult(options.clean ? {} : instance, schema, options, ctx);
   var properties = schema.properties || {};
   for (var property in properties) {
     var prop = (instance || undefined) && instance[property];
@@ -279,7 +281,9 @@ validators.items = function validateItems (instance, schema, options, ctx) {
     return null;
   }
   var self = this;
-  var result = new ValidatorResult(instance, schema, options, ctx);
+  // With `clean` option set we want to create a copy of the instance in the result to ensure that the original
+  // array is not modified.
+  var result = new ValidatorResult(options.clean ? [].concat(instance) : instance, schema, options, ctx);
   if (instance === undefined || !schema.items) {
     return result;
   }

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -150,6 +150,22 @@ Validator.prototype.validate = function validate (instance, schema, options, ctx
 };
 
 /**
+ * Validates instance against the provided schema and strips undeclared properties out of instance
+ * @param instance
+ * @param schema
+ * @param [options]
+ * @param [ctx]
+ * @return {Array}
+ */
+Validator.prototype.validateAndClean = function validateAndClean (instance, schema, options, ctx) {
+  options = options || {};
+
+  options.clean = true;
+
+  return this.validate(instance, schema, options, ctx);
+};
+
+/**
  * Validates an instance against the schema (the actual work horse)
  * @param instance
  * @param schema
@@ -218,12 +234,13 @@ Validator.prototype.validateSchema = function validateSchema (instance, schema, 
       }
       if (validatorErr) {
         result.importErrors(validatorErr);
+        if (validatorErr.instance !== result.instance) result.instance = validatorErr.instance;
       }
     }
   }
 
   if (typeof options.rewrite == 'function') {
-    var value = options.rewrite.call(this, instance, schema, options, ctx);
+    var value = options.rewrite.call(this, result.instance, schema, options, ctx);
     result.instance = value;
   }
   return result;

--- a/test/options.js
+++ b/test/options.js
@@ -1,0 +1,125 @@
+'use strict';
+
+/*jsl predef:define*/
+/*jsl predef:it*/
+
+var Validator = require('../lib/validator');
+var should = require('chai').should();
+
+describe('Option', function () {
+  beforeEach(function () {
+    this.validator = new Validator();
+  });
+
+  describe('clean:true', function() {
+    var nameSchema = {
+      type: 'object',
+      properties: {
+        name: { type:'string' }
+      }
+    };
+
+    var cleanOption = {
+      clean: true
+    };
+
+    it('should leave a declared property', function() {
+      this.validator.validate({
+        name: 'test',
+        age: 42
+      }, nameSchema, cleanOption).instance.should.have.property('name');
+    });
+
+    it('should remove an undelared property', function() {
+      this.validator.validate({
+        name: 'test',
+        age: 42
+      }, nameSchema, cleanOption).instance.should.not.have.property('age');
+    });
+
+    it('should not modify original instance', function() {
+      var instance = {
+        name: 'test',
+        age: 42
+      };
+      var result = this.validator.validate(instance, nameSchema, cleanOption);
+      instance.should.have.property('age');
+    });
+
+    it('should leave a declared nested property', function() {
+      this.validator.validate({
+        nested: {
+          name: 'test',
+          age: 42
+        }
+      }, {
+        type: 'object',
+        properties: {
+          nested: nameSchema
+        }
+      }, cleanOption).instance.nested.should.have.property('name');
+    });
+
+    it('should remove an undelared nested property', function() {
+      this.validator.validate({
+        nested: {
+          name: 'test',
+          age: 42
+        }
+      }, {
+        type: 'object',
+        properties: {
+          nested: nameSchema
+        }
+      }, cleanOption).instance.nested.should.not.have.property('age');
+    });
+
+    it('should not modify original instance with nested properties', function() {
+      var instance = {
+        nested: {
+          name: 'test',
+          age: 42
+        }
+      };
+      var result = this.validator.validate(instance, {
+        type: 'object',
+        properties: {
+          nested: nameSchema
+        }
+      }, cleanOption);
+      instance.nested.should.have.property('age');
+    });
+
+    it('should leave a declared property in an array item', function() {
+      this.validator.validate([{
+        name: 'test',
+        age: 42
+      }], {
+        type: 'array',
+        items: nameSchema
+      }, cleanOption).instance[0].should.have.property('name');
+    });
+
+    it('should remove an undelared property in an array item', function() {
+      this.validator.validate([{
+        name: 'test',
+        age: 42
+      }], {
+        type: 'array',
+        items: nameSchema
+      }, cleanOption).instance[0].should.not.have.property('age');
+    });
+
+    it('should not modify original array instance or items', function() {
+      var instance = [{
+        name: 'test',
+        age: 42
+      }];
+      var result = this.validator.validate(instance, {
+        type: 'array',
+        items: nameSchema
+      }, cleanOption);
+      instance[0].should.have.property('age');
+    });
+  });
+});


### PR DESCRIPTION
There are two methods to trigger this. Either use `validator.validateAndClean(...)`, or pass the `clean:true` option. In either case the result is that the `result.instance` will no longer be a reference, but a clone of the original instance passed in and, for objects in the instance, properties not declared in the schema will have been removed. See the tests for some more examples.

```js
var dude = {
  name: 'test',
  age: 42
};

var res = validator.validate(dude, {
  type: 'object',
  properties: {
    name: { type:'string' }
  }
}, {
  clean: true
});

dude; // unchanged: { name:'test', age:42 }
res.instance; // clean: { name:'test' }
```

**Regarding implementation**, I started by adding a `rewrite` option but did not like that it added extra property traversals on the objects to clone them or remove properties. The solution I ended up with is not the simplest to follow but resulted in no extra loops. This is my first jaunt into this code so don't hesitate to let me know if I've overcomplicated or if you just think this doesn't belong.

I didn't see any tests around the `options` parameter so I added a test file called `options.js` and added my tests there. Let me know if there is a better place for these tests.

There does not appear to be any documentation regarding options in the readme today, but this is something that we may want to add if you decide to accept this PR.

Closes #99