### PR TITLE
Validation message i18n / Custom error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,122 @@ them:
   importNextSchema();
 ```
 
+### Custom error messages / i18n
+
+Specify your own error messages with the ValidatorResult.mapErrors function:
+
+```javascript
+var Validator = require('jsonschema').Validator;
+var v = new Validator();
+
+var errorMap = {
+  "en": {
+    'instance.customPropertyMessage': 'Custom error message',
+    'instance.customValidatorTypeMessage': {
+      'message': 'Custom general message',
+      'minimum': 'Must be greater than three'
+    },
+    'instance.customValidatorSubTypeMessage': {
+      'format': {
+        'ipv4': 'Not an IP address'
+      }
+    },
+    'instance.array1': {
+      'minItems': 'Not enough items'
+    },
+    'instance.array2': {
+      'minItems': 'Not enough items'
+    },
+    'instance.array2[]': {
+      type: 'Array item must be an integer'
+    },
+    'instance.array2[3]': {
+      type: 'Array item 3 must be an integer'
+    }
+  },
+  "fr": {
+    'instance.customPropertyMessage': "Message d'erreur personnalisé",
+    'instance.customValidatorTypeMessage': {
+      'message': "Message personnalisé générale",
+      'minimum': 'Doit être supérieur à trois',
+    },
+    'instance.customValidatorSubTypeMessage': {
+      'format': {
+        'ipv4': 'Pas une adresse IP'
+      }
+    }
+  }
+};
+
+var schema = {
+  "id": "/i18n",
+  "type": "object",
+  "properties": {
+    noCustomMessage: {
+      type: 'integer'
+    },
+    customPropertyMessage: {
+      type: 'integer'
+    },
+    customValidatorTypeMessage: {
+      type: 'integer',
+      minimum: 3
+    },
+    customValidatorSubTypeMessage: {
+      type: 'string',
+      format: 'ipv4'
+    },
+    array1: {
+      type: 'array',
+      minItems: 2
+    },
+    array2: {
+      type: 'array',
+      minItems: 2,
+      items: {
+        type: 'integer'
+      }
+    }
+  }
+};
+
+var instance = {
+  noCustomMessage: 'not-an-int',
+  customPropertyMessage: 'not-an-int',
+  customValidatorTypeMessage: 2, // Below minimum
+  customValidatorSubTypeMessage: 'not-an-IP-address',
+  array1: [1],
+  array2: [1, 2, 'a', 'b']
+};
+
+var resultEnglish = v.validate(instance, schema).mapErrors(errorMap.en);
+var resultFrench = v.validate(instance, schema).mapErrors(errorMap.fr);
+```
+
+Or use a custom function to provide your own error message mappings:
+
+```javascript
+var resultCustom = v.validate(instance, schema).mapErrors(function (err) {
+  if (!err) return err;
+
+  // The path to the property
+  var propPath = err.property;
+  // The validator type (name of validator)
+  var validatorType = err.validatorType;
+  // The validator sub-type (only applicable for validators like format)
+  var validatorSubType = err.validatorSubType;
+
+  if (propPath === 'instance.customValidatorSubTypeMessage'
+    && validatorType === 'format'
+    && validatorSubType === 'ipv4') {
+      err.message = 'Not an IP address';
+      return err;
+  }
+
+  return err;
+}));
+```
+
 ## Tests
 Uses [JSON Schema Test Suite](https://github.com/json-schema/JSON-Schema-Test-Suite) as well as our own tests.
 You'll need to update and init the git submodules:

--- a/examples/i18n.js
+++ b/examples/i18n.js
@@ -4,11 +4,6 @@ var util = require('util');
 var Validator = require('jsonschema').Validator;
 
 /*
-  Default locale for errors
-*/
-var DEFAULT_ERROR_LOCALE = 'en';
-
-/*
   Translation/custom error mappings
 */
 var errorMap = {
@@ -65,69 +60,11 @@ var instance = {
   customValidatorTypeMessage: 2, // Below minimum
   customValidatorSubTypeMessage: 'not-an-IP-address'
 };
-console.log(i18n(v.validate(instance, schema), errorMap));
-console.log(i18n(v.validate(instance, schema), errorMap, 'fr'));
 
-/**
-  Provides custom error messages or localises a validation result
- */
-function i18n(result, errorMap, locale) {
-  locale = locale || DEFAULT_ERROR_LOCALE;
-  var map = errorMap[locale];
-  if (!map) throw new Error('Missing error map for locale: ' + locale);
+// English
+console.log(v.validate(instance, schema).mapErrors(errorMap.en));
 
-  // Only process results which have failed validation
-  if (!result.valid && result.errors) {
-    result.errors = result.errors.map(function (err) {
-      return mapError(map, err);
-    });
-  }
-  return result;
-}
+// French
+console.log(v.validate(instance, schema).mapErrors(errorMap.fr));
 
-/**
-  Maps a validation error to a custom error
-*/
-function mapError(map, err) {
-  if (!err) return err;
 
-  // Get the property path, validator type and validator sub-type from the error
-  var propPath = err.property;
-  var validatorType = err.validatorType;
-  var validatorSubType = err.validatorSubType;
-
-  // Check for a custom error for the property path
-  var msgProp = map[propPath];
-  if (!msgProp) {
-    // No custom message
-    return err;
-  }
-  if (typeof msgProp === 'string') {
-    // Only a single message for this property
-    err.message = msgProp;
-    return err;
-  }
-
-  // Check for a custom error for the validator type
-  var valProp = validatorType ? msgProp[validatorType] : null;
-  if (!valProp) {
-    // No custom validator message
-    err.message = msgProp.message || err.message;
-    return err;
-  }
-  if (typeof valProp === 'string') {
-    // Only a single message for this validator
-    err.message = valProp;
-    return err;
-  }
-
-  // Check for a custom error for the validator sub-type
-  var subValProp = validatorSubType ? valProp[validatorSubType] : null;
-  if (!subValProp) {
-    err.message = valProp.message || err.message;
-    return err;
-  }
-
-  err.message = subValProp;
-  return err;
-}

--- a/examples/i18n.js
+++ b/examples/i18n.js
@@ -17,6 +17,18 @@ var errorMap = {
       'format': {
         'ipv4': 'Not an IP address'
       }
+    },
+    'instance.array1': {
+      'minItems': 'Not enough items'
+    },
+    'instance.array2': {
+      'minItems': 'Not enough items'
+    },
+    'instance.array2[]': {
+      'type': 'Array item must be an integer'
+    },
+    'instance.array2[3]': {
+      'type': 'Array item 3 must be an integer'
     }
   },
   "fr": {
@@ -51,6 +63,17 @@ var schema = {
     customValidatorSubTypeMessage: {
       type: 'string',
       format: 'ipv4'
+    },
+    array1: {
+      type: 'array',
+      minItems: 2
+    },
+    array2: {
+      type: 'array',
+      minItems: 2,
+      items: {
+        type: 'integer'
+      }
     }
   }
 };
@@ -58,7 +81,9 @@ var instance = {
   noCustomMessage: 'not-an-int',
   customPropertyMessage: 'not-an-int',
   customValidatorTypeMessage: 2, // Below minimum
-  customValidatorSubTypeMessage: 'not-an-IP-address'
+  customValidatorSubTypeMessage: 'not-an-IP-address',
+  array1: [1],
+  array2: [1, 2, 'a', 'b']
 };
 
 // English

--- a/examples/i18n.js
+++ b/examples/i18n.js
@@ -1,0 +1,133 @@
+'use strict';
+
+var util = require('util');
+var Validator = require('jsonschema').Validator;
+
+/*
+  Default locale for errors
+*/
+var DEFAULT_ERROR_LOCALE = 'en';
+
+/*
+  Translation/custom error mappings
+*/
+var errorMap = {
+  "en": {
+    'instance.customPropertyMessage': 'Custom error message',
+    'instance.customValidatorTypeMessage': {
+      'message': 'Custom general message',
+      'minimum': 'Must be greater than three'
+    },
+    'instance.customValidatorSubTypeMessage': {
+      'format': {
+        'ipv4': 'Not an IP address'
+      }
+    }
+  },
+  "fr": {
+    'instance.customPropertyMessage': "Message d'erreur personnalisé",
+    'instance.customValidatorTypeMessage': {
+      'message': "Message personnalisé générale",
+      'minimum': 'Doit être supérieur à trois',
+    },
+    'instance.customValidatorSubTypeMessage': {
+      'format': {
+        'ipv4': 'Pas une adresse IP'
+      }
+    }
+  }
+};
+
+var v = new Validator();
+var schema = {
+  "id": "/i18n",
+  "type": "object",
+  "properties": {
+    noCustomMessage: {
+      type: 'integer'
+    },
+    customPropertyMessage: {
+      type: 'integer'
+    },
+    customValidatorTypeMessage: {
+      type: 'integer',
+      minimum: 3
+    },
+    customValidatorSubTypeMessage: {
+      type: 'string',
+      format: 'ipv4'
+    }
+  }
+};
+var instance = {
+  noCustomMessage: 'not-an-int',
+  customPropertyMessage: 'not-an-int',
+  customValidatorTypeMessage: 2, // Below minimum
+  customValidatorSubTypeMessage: 'not-an-IP-address'
+};
+console.log(i18n(v.validate(instance, schema), errorMap));
+console.log(i18n(v.validate(instance, schema), errorMap, 'fr'));
+
+/**
+  Provides custom error messages or localises a validation result
+ */
+function i18n(result, errorMap, locale) {
+  locale = locale || DEFAULT_ERROR_LOCALE;
+  var map = errorMap[locale];
+  if (!map) throw new Error('Missing error map for locale: ' + locale);
+
+  // Only process results which have failed validation
+  if (!result.valid && result.errors) {
+    result.errors = result.errors.map(function (err) {
+      return mapError(map, err);
+    });
+  }
+  return result;
+}
+
+/**
+  Maps a validation error to a custom error
+*/
+function mapError(map, err) {
+  if (!err) return err;
+
+  // Get the property path, validator type and validator sub-type from the error
+  var propPath = err.property;
+  var validatorType = err.validatorType;
+  var validatorSubType = err.validatorSubType;
+
+  // Check for a custom error for the property path
+  var msgProp = map[propPath];
+  if (!msgProp) {
+    // No custom message
+    return err;
+  }
+  if (typeof msgProp === 'string') {
+    // Only a single message for this property
+    err.message = msgProp;
+    return err;
+  }
+
+  // Check for a custom error for the validator type
+  var valProp = validatorType ? msgProp[validatorType] : null;
+  if (!valProp) {
+    // No custom validator message
+    err.message = msgProp.message || err.message;
+    return err;
+  }
+  if (typeof valProp === 'string') {
+    // Only a single message for this validator
+    err.message = valProp;
+    return err;
+  }
+
+  // Check for a custom error for the validator sub-type
+  var subValProp = validatorSubType ? valProp[validatorSubType] : null;
+  if (!subValProp) {
+    err.message = valProp.message || err.message;
+    return err;
+  }
+
+  err.message = subValProp;
+  return err;
+}

--- a/examples/i18n.js
+++ b/examples/i18n.js
@@ -67,4 +67,23 @@ console.log(v.validate(instance, schema).mapErrors(errorMap.en));
 // French
 console.log(v.validate(instance, schema).mapErrors(errorMap.fr));
 
+// Custom error function
+console.log(v.validate(instance, schema).mapErrors(function (err) {
+  if (!err) return err;
 
+  // The path to the property
+  var propPath = err.property;
+  // The validator type (name of validator)
+  var validatorType = err.validatorType;
+  // The validator sub-type (only applicable for validators like format)
+  var validatorSubType = err.validatorSubType;
+
+  if (propPath === 'instance.customValidatorSubTypeMessage'
+    && validatorType === 'format'
+    && validatorSubType === 'ipv4') {
+      err.message = 'Not an IP address';
+      return err;
+  }
+
+  return err;
+}));

--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -46,9 +46,14 @@ validators.type = function validateType (instance, schema, options, ctx) {
   var result = new ValidatorResult(instance, schema, options, ctx);
   var types = (schema.type instanceof Array) ? schema.type : [schema.type];
   if (!types.some(this.testType.bind(this, instance, schema, options, ctx))) {
+
+    //NOTE: Not sure this is the correct way to handle this scenario...
+    schema.type.sort();
+    var subType = schema.type.join();
+
     result.addError({
       validatorType: 'type',
-      validatorSubType: schema.type,
+      validatorSubType: subType,
       message: "is not of a type(s) " + types.map(function (v) {
         return v.id && ('<' + v.id + '>') || (v+'');
       })

--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -43,13 +43,18 @@ validators.type = function validateType (instance, schema, options, ctx) {
   if (instance === undefined) {
     return null;
   }
+  var result = new ValidatorResult(instance, schema, options, ctx);
   var types = (schema.type instanceof Array) ? schema.type : [schema.type];
   if (!types.some(this.testType.bind(this, instance, schema, options, ctx))) {
-    return "is not of a type(s) " + types.map(function (v) {
-      return v.id && ('<' + v.id + '>') || (v+'');
+    result.addError({
+      validatorType: 'type',
+      validatorSubType: schema.type,
+      message: "is not of a type(s) " + types.map(function (v) {
+        return v.id && ('<' + v.id + '>') || (v+'');
+      })
     });
   }
-  return null;
+  return result;
 };
 
 function testSchema(instance, options, ctx, schema){
@@ -69,15 +74,19 @@ validators.anyOf = function validateAnyOf (instance, schema, options, ctx) {
   if (instance === undefined) {
     return null;
   }
+  var result = new ValidatorResult(instance, schema, options, ctx);
   if (!(schema.anyOf instanceof Array)){
     throw new SchemaError("anyOf must be an array");
   }
   if (!schema.anyOf.some(testSchema.bind(this, instance, options, ctx))) {
-    return "is not any of " + schema.anyOf.map(function (v, i) {
-      return (v.id && ('<' + v.id + '>')) || (v.title && JSON.stringify(v.title)) || (v['$ref'] && ('<' + v['$ref'] + '>')) || '[subschema '+i+']';
+    result.addError({
+      validatorType: 'anyOf',
+      message: "is not any of " + schema.anyOf.map(function (v, i) {
+        return (v.id && ('<' + v.id + '>')) || (v.title && JSON.stringify(v.title)) || (v['$ref'] && ('<' + v['$ref'] + '>')) || '[subschema '+i+']';
+      })
     });
   }
-  return null;
+  return result;
 };
 
 /**
@@ -89,7 +98,6 @@ validators.anyOf = function validateAnyOf (instance, schema, options, ctx) {
  * @return {String|null}
  */
 validators.allOf = function validateAllOf (instance, schema, options, ctx) {
-  var result = new ValidatorResult(instance, schema, options, ctx);
   // Ignore undefined instances
   if (instance === undefined) {
     return null;
@@ -97,12 +105,16 @@ validators.allOf = function validateAllOf (instance, schema, options, ctx) {
   if (!(schema.allOf instanceof Array)){
     throw new SchemaError("allOf must be an array");
   }
+  var result = new ValidatorResult(instance, schema, options, ctx);
   var self = this;
   schema.allOf.forEach(function(v, i){
     var valid = self.validateSchema(instance, v, options, ctx);
     if(!valid.valid){
       var msg = (v.id && ('<' + v.id + '>')) || (v.title && JSON.stringify(v.title)) || (v['$ref'] && ('<' + v['$ref'] + '>')) || '[subschema '+i+']';
-      result.addError('does not match allOf schema ' + msg + ' with ' + valid.errors.length + ' error[s]:');
+      result.addError({
+        validatorType: 'allOf',
+        message: 'does not match allOf schema ' + msg + ' with ' + valid.errors.length + ' error[s]:'
+      });
       result.importErrors(valid);
     }
   });
@@ -125,13 +137,17 @@ validators.oneOf = function validateOneOf (instance, schema, options, ctx) {
   if (!(schema.oneOf instanceof Array)){
     throw new SchemaError("oneOf must be an array");
   }
+  var result = new ValidatorResult(instance, schema, options, ctx);
   var count = schema.oneOf.filter(testSchema.bind(this, instance, options, ctx)).length;
   if (count!==1) {
-    return "is not exactly one from " + schema.oneOf.map(function (v, i) {
-      return (v.id && ('<' + v.id + '>')) || (v.title && JSON.stringify(v.title)) || (v['$ref'] && ('<' + v['$ref'] + '>')) || '[subschema '+i+']';
+    result.addError({
+      validatorType: 'oneOf',
+      message: "is not exactly one from " + schema.oneOf.map(function (v, i) {
+        return (v.id && ('<' + v.id + '>')) || (v.title && JSON.stringify(v.title)) || (v['$ref'] && ('<' + v['$ref'] + '>')) || '[subschema '+i+']';
+      })
     });
   }
-  return null;
+  return result;
 };
 
 /**
@@ -167,7 +183,10 @@ function testAdditionalProperty (instance, schema, options, ctx, property, resul
     return;
   }
   if (schema.additionalProperties === false) {
-    result.addError("additionalProperty '"+property+"' exists in instance when not allowed");
+    result.addError({
+      validatorType: 'additionalProperties',
+      message: "additionalProperty '"+property+"' exists in instance when not allowed"
+    });
   } else {
     var additionalProperties = schema.additionalProperties || {};
     var res = this.validateSchema(instance[property], additionalProperties, options, ctx.makeChild(additionalProperties, property));
@@ -238,15 +257,19 @@ validators.additionalProperties = function validateAdditionalProperties (instanc
  * @param schema
  * @return {String|null}
  */
-validators.minProperties = function validateMinProperties (instance, schema) {
+validators.minProperties = function validateMinProperties (instance, schema, options, ctx) {
   if (!instance || typeof instance !== 'object') {
     return null;
   }
+  var result = new ValidatorResult(instance, schema, options, ctx);
   var keys = Object.keys(instance);
   if (!(keys.length >= schema.minProperties)) {
-    return "does not meet minimum property length of " + schema.minProperties;
+    result.addError({
+      validatorType: 'minProperties',
+      message: "does not meet minimum property length of " + schema.minProperties
+    })
   }
-  return null;
+  return result;
 };
 
 /**
@@ -255,15 +278,19 @@ validators.minProperties = function validateMinProperties (instance, schema) {
  * @param schema
  * @return {String|null}
  */
-validators.maxProperties = function validateMaxProperties (instance, schema) {
+validators.maxProperties = function validateMaxProperties (instance, schema, options, ctx) {
   if (!instance || typeof instance !== 'object') {
     return null;
   }
+  var result = new ValidatorResult(instance, schema, options, ctx);
   var keys = Object.keys(instance);
   if (!(keys.length <= schema.maxProperties)) {
-    return "does not meet maximum property length of " + schema.maxProperties;
+    result.addError({
+      validatorType: 'maxProperties',
+      message: "does not meet maximum property length of " + schema.maxProperties
+    });
   }
-  return null;
+  return result;
 };
 
 /**
@@ -289,7 +316,10 @@ validators.items = function validateItems (instance, schema, options, ctx) {
       return true;
     }
     if (items === false) {
-      result.addError("additionalItems not permitted");
+      result.addError({
+        validatorType: 'items',
+        message: "additionalItems not permitted"
+      });
       return false;
     }
     var res = self.validateSchema(value, items, options, ctx.makeChild(items, i));
@@ -306,10 +336,11 @@ validators.items = function validateItems (instance, schema, options, ctx) {
  * @param schema
  * @return {String|null}
  */
-validators.minimum = function validateMinimum (instance, schema) {
+validators.minimum = function validateMinimum (instance, schema, options, ctx) {
   if (typeof instance !== 'number') {
     return null;
   }
+  var result = new ValidatorResult(instance, schema, options, ctx);
   var valid = true;
   if (schema.exclusiveMinimum && schema.exclusiveMinimum === true) {
     valid = instance > schema.minimum;
@@ -317,9 +348,12 @@ validators.minimum = function validateMinimum (instance, schema) {
     valid = instance >= schema.minimum;
   }
   if (!valid) {
-    return "must have a minimum value of " + schema.minimum;
+    result.addError({
+      validatorType: 'minimum',
+      message: "must have a minimum value of " + schema.minimum
+    });
   }
-  return null;
+  return result;
 };
 
 /**
@@ -328,10 +362,11 @@ validators.minimum = function validateMinimum (instance, schema) {
  * @param schema
  * @return {String|null}
  */
-validators.maximum = function validateMaximum (instance, schema) {
+validators.maximum = function validateMaximum (instance, schema, options, ctx) {
   if (typeof instance !== 'number') {
     return null;
   }
+  var result = new ValidatorResult(instance, schema, options, ctx);
   var valid;
   if (schema.exclusiveMaximum && schema.exclusiveMaximum === true) {
     valid = instance < schema.maximum;
@@ -339,9 +374,12 @@ validators.maximum = function validateMaximum (instance, schema) {
     valid = instance <= schema.maximum;
   }
   if (!valid) {
-    return "must have a maximum value of " + schema.maximum;
+    result.addError({
+      validatorType: 'maximum',
+      message: "must have a maximum value of " + schema.maximum
+    });
   }
-  return null;
+  return result;
 };
 
 /**
@@ -352,7 +390,7 @@ validators.maximum = function validateMaximum (instance, schema) {
  * @param schema
  * @return {String|null}
  */
-validators.divisibleBy = function validateDivisibleBy (instance, schema) {
+validators.divisibleBy = function validateDivisibleBy (instance, schema, options, ctx) {
   if (typeof instance !== 'number') {
     return null;
   }
@@ -361,10 +399,14 @@ validators.divisibleBy = function validateDivisibleBy (instance, schema) {
     throw new SchemaError("divisibleBy cannot be zero");
   }
 
+  var result = new ValidatorResult(instance, schema, options, ctx);
   if (instance / schema.divisibleBy % 1) {
-    return "is not " + schema.divisibleBy;
+    result.addError({
+      validatorType: 'divisibleBy',
+      message: "is not " + schema.divisibleBy
+    });
   }
-  return null;
+  return result;
 };
 
 /**
@@ -375,7 +417,7 @@ validators.divisibleBy = function validateDivisibleBy (instance, schema) {
  * @param schema
  * @return {String|null}
  */
-validators.multipleOf = function validateMultipleOf (instance, schema) {
+validators.multipleOf = function validateMultipleOf (instance, schema, options, ctx) {
   if (typeof instance !== 'number') {
     return null;
   }
@@ -384,10 +426,14 @@ validators.multipleOf = function validateMultipleOf (instance, schema) {
     throw new SchemaError("multipleOf cannot be zero");
   }
 
+  var result = new ValidatorResult(instance, schema, options, ctx);
   if (instance / schema.multipleOf % 1) {
-    return "is not " + schema.multipleOf;
+    result.addError({
+      validatorType: 'multipleOf',
+      message: "is not " + schema.multipleOf
+    });
   }
-  return null;
+  return result;
 };
 
 /**
@@ -397,18 +443,25 @@ validators.multipleOf = function validateMultipleOf (instance, schema) {
  * @return {String|null}
  */
 validators.required = function validateRequired (instance, schema, options, ctx) {
+  var result = new ValidatorResult(instance, schema, options, ctx);
   if (instance === undefined && schema.required === true) {
-    return "is required";
-  }else if (instance && typeof instance==='object' && Array.isArray(schema.required)) {
-    var result = new ValidatorResult(instance, schema, options, ctx);
+    result.addError({
+      validatorType: 'required',
+      message: "is required"
+    });
+  } else if (instance && typeof instance==='object' && Array.isArray(schema.required)) {
     schema.required.forEach(function(n){
       if(instance[n]===undefined){
-        result.addError("requires property "+JSON.stringify(n));
+        var requireVal = JSON.stringify(n);
+        result.addError({
+          validatorType: 'required',
+          validatorSubType: requireVal,
+          message: "requires property " + requireVal
+        });
       }
     });
-    return result;
   }
-  return null;
+  return result;
 };
 
 /**
@@ -417,14 +470,18 @@ validators.required = function validateRequired (instance, schema, options, ctx)
  * @param schema
  * @return {String|null}
  */
-validators.pattern = function validatePattern (instance, schema) {
+validators.pattern = function validatePattern (instance, schema, options, ctx) {
   if (typeof instance !== 'string') {
     return null;
   }
+  var result = new ValidatorResult(instance, schema, options, ctx);
   if (!instance.match(schema.pattern)) {
-    return "does not match pattern " + schema.pattern;
+    result.addError({
+      validatorType: 'pattern',
+      message: "does not match pattern " + schema.pattern
+    });
   }
-  return null;
+  return result;
 };
 
 /**
@@ -451,10 +508,15 @@ validators.format = function validateFormat (instance, schema, options, ctx) {
   if (!(typeof instance === 'string')) {
     return null;
   }
+  var result = new ValidatorResult(instance, schema, options, ctx);
   if (!helpers.isFormat(instance, schema.format)) {
-    return "does not conform to the '" + schema.format + "' format";
+    result.addError({
+      validatorType: 'format',
+      validatorSubType: schema.format,
+      message: "does not conform to the '" + schema.format + "' format"
+    });
   }
-  return null;
+  return result;
 };
 
 /**
@@ -463,14 +525,18 @@ validators.format = function validateFormat (instance, schema, options, ctx) {
  * @param schema
  * @return {String|null}
  */
-validators.minLength = function validateMinLength (instance, schema) {
+validators.minLength = function validateMinLength (instance, schema, options, ctx) {
   if (!(typeof instance === 'string')) {
     return null;
   }
+  var result = new ValidatorResult(instance, schema, options, ctx);
   if (!(instance.length >= schema.minLength)) {
-    return "does not meet minimum length of " + schema.minLength;
+    result.addError({
+      validatorType: 'minLength',
+      message: "does not meet minimum length of " + schema.minLength
+    });
   }
-  return null;
+  return result;
 };
 
 /**
@@ -479,14 +545,18 @@ validators.minLength = function validateMinLength (instance, schema) {
  * @param schema
  * @return {String|null}
  */
-validators.maxLength = function validateMaxLength (instance, schema) {
+validators.maxLength = function validateMaxLength (instance, schema, options, ctx) {
   if (!(typeof instance === 'string')) {
     return null;
   }
+  var result = new ValidatorResult(instance, schema, options, ctx);
   if (!(instance.length <= schema.maxLength)) {
-    return "does not meet maximum length of " + schema.maxLength;
+    result.addError({
+      validatorType: 'maxLength',
+      message: "does not meet maximum length of " + schema.maxLength
+    });
   }
-  return null;
+  return result;
 };
 
 /**
@@ -495,14 +565,18 @@ validators.maxLength = function validateMaxLength (instance, schema) {
  * @param schema
  * @return {String|null}
  */
-validators.minItems = function validateMinItems (instance, schema) {
+validators.minItems = function validateMinItems (instance, schema, options, ctx) {
   if (!(instance instanceof Array)) {
     return null;
   }
+  var result = new ValidatorResult(instance, schema, options, ctx);
   if (!(instance.length >= schema.minItems)) {
-    return "does not meet minimum length of " + schema.minItems;
+    result.addError({
+      validatorType: 'minItems',
+      message: "does not meet minimum length of " + schema.minItems
+    });
   }
-  return null;
+  return result;
 };
 
 /**
@@ -511,14 +585,18 @@ validators.minItems = function validateMinItems (instance, schema) {
  * @param schema
  * @return {String|null}
  */
-validators.maxItems = function validateMaxItems (instance, schema) {
+validators.maxItems = function validateMaxItems (instance, schema, options, ctx) {
   if (!(instance instanceof Array)) {
     return null;
   }
+  var result = new ValidatorResult(instance, schema, options, ctx);
   if (!(instance.length <= schema.maxItems)) {
-    return "does not meet maximum length of " + schema.maxItems;
+    result.addError({
+      validatorType: 'maxItems',
+      message: "does not meet maximum length of " + schema.maxItems
+    });
   }
-  return null;
+  return result;
 };
 
 /**
@@ -541,7 +619,10 @@ validators.uniqueItems = function validateUniqueItems (instance, schema, options
     return true;
   }
   if (!instance.every(testArrays)) {
-    result.addError("contains duplicate item");
+    result.addError({
+      validatorType: 'uniqueItems',
+      message: "contains duplicate item"
+    });
   }
   return result;
 };
@@ -569,15 +650,18 @@ function testArrays (v, i, a) {
  * @param instance
  * @return {String|null}
  */
-validators.uniqueItems = function validateUniqueItems (instance) {
+validators.uniqueItems = function validateUniqueItems (instance, schema, options, ctx) {
   if (!(instance instanceof Array)) {
     return null;
   }
-
+  var result = new ValidatorResult(instance, schema, options, ctx);
   if (!instance.every(testArrays)) {
-    return "contains duplicate item";
+    result.addError({
+      validatorType: 'uniqueItems',
+      message: "contains duplicate item"
+    });
   }
-  return null;
+  return result;
 };
 
 /**
@@ -589,10 +673,10 @@ validators.uniqueItems = function validateUniqueItems (instance) {
  * @return {String|null|ValidatorResult}
  */
 validators.dependencies = function validateDependencies (instance, schema, options, ctx) {
-  var result = new ValidatorResult(instance, schema, options, ctx);
   if (!instance || typeof instance != 'object') {
     return null;
   }
+  var result = new ValidatorResult(instance, schema, options, ctx);
   for (var property in schema.dependencies) {
     if (instance[property] === undefined) {
       continue;
@@ -605,14 +689,20 @@ validators.dependencies = function validateDependencies (instance, schema, optio
     if (dep instanceof Array) {
       dep.forEach(function (prop) {
         if (instance[prop] === undefined) {
-          result.addError("property " + prop + " not found, required by " + childContext.propertyPath);
+          result.addError({
+            validatorType: 'dependencies',
+            message: "property " + prop + " not found, required by " + childContext.propertyPath
+          });
         }
       });
     } else {
       var res = this.validateSchema(instance, dep, options, childContext);
       if(result.instance !== res.instance) result.instance = res.instance;
       if (res && res.errors.length) {
-        result.addError("does not meet dependency required by " + childContext.propertyPath);
+        result.addError({
+          validatorType: 'dependencies',
+          message: "does not meet dependency required by " + childContext.propertyPath
+        });
         result.importErrors(res);
       }
     }
@@ -627,17 +717,21 @@ validators.dependencies = function validateDependencies (instance, schema, optio
  * @param schema
  * @return {String|null}
  */
-validators.enum = function validateEnum (instance, schema) {
+validators.enum = function validateEnum (instance, schema, options, ctx) {
   if (!(schema.enum instanceof Array)) {
     throw new SchemaError("enum expects an array", schema);
   }
   if (instance === undefined) {
     return null;
   }
+  var result = new ValidatorResult(instance, schema, options, ctx);
   if (!schema.enum.some(helpers.deepCompareStrict.bind(null, instance))) {
-    return "is not one of enum values: " + schema.enum;
+    result.addError({
+      validatorType: 'enum',
+      message: "is not one of enum values: " + schema.enum
+    });
   }
-  return null;
+  return result;
 };
 
 /**
@@ -658,7 +752,10 @@ validators.not = validators.disallow = function validateNot (instance, schema, o
   notTypes.forEach(function (type) {
     if (self.testType(instance, schema, options, ctx, type)) {
       var schemaId = type && type.id && ('<' + type.id + '>') || type;
-      result.addError("is of prohibited type " + schemaId);
+      result.addError({
+        validatorType: 'not',
+        message: "is of prohibited type " + schemaId
+      });
     }
   });
   return result;

--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -46,14 +46,8 @@ validators.type = function validateType (instance, schema, options, ctx) {
   var result = new ValidatorResult(instance, schema, options, ctx);
   var types = (schema.type instanceof Array) ? schema.type : [schema.type];
   if (!types.some(this.testType.bind(this, instance, schema, options, ctx))) {
-
-    //NOTE: Not sure this is the correct way to handle this scenario...
-    schema.type.sort();
-    var subType = schema.type.join();
-
     result.addError({
       validatorType: 'type',
-      validatorSubType: subType,
       message: "is not of a type(s) " + types.map(function (v) {
         return v.id && ('<' + v.id + '>') || (v+'');
       })

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -25,7 +25,7 @@ var ValidationError = exports.ValidationError = function ValidationError (messag
 };
 
 ValidationError.prototype.toString = function toString() {
-  return this.property + ' ' + this.message;
+  return this.customMessage ? this.message : this.property + ' ' + this.message;
 };
 
 var ValidatorResult = exports.ValidatorResult = function ValidatorResult(instance, schema, options, ctx) {
@@ -90,6 +90,8 @@ ValidatorResult.prototype.mapErrors = function mapErrors(errorMap) {
 function mapError(map, err) {
   if (!err) return err;
 
+  err.customMessage = false;
+
   // Get the property path, validator type and validator sub-type from the error
   var propPath = err.property;
   var validatorType = err.validatorType;
@@ -104,6 +106,7 @@ function mapError(map, err) {
   if (typeof msgProp === 'string') {
     // Only a single message for this property
     err.message = msgProp;
+    err.customMessage = true;
     return err;
   }
 
@@ -112,11 +115,13 @@ function mapError(map, err) {
   if (!valProp) {
     // No custom validator message
     err.message = msgProp.message || err.message;
+    err.customMessage = true;
     return err;
   }
   if (typeof valProp === 'string') {
     // Only a single message for this validator
     err.message = valProp;
+    err.customMessage = true;
     return err;
   }
 
@@ -124,10 +129,12 @@ function mapError(map, err) {
   var subValProp = validatorSubType ? valProp[validatorSubType] : null;
   if (!subValProp) {
     err.message = valProp.message || err.message;
+    err.customMessage = true;
     return err;
   }
 
   err.message = subValProp;
+  err.customMessage = true;
   return err;
 }
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -69,6 +69,68 @@ ValidatorResult.prototype.toString = function toString(res) {
   return this.errors.map(function(v,i){ return i+': '+v.toString()+'\n'; }).join('');
 };
 
+/**
+  Provides custom error messages or localises a validation result
+ */
+ValidatorResult.prototype.mapErrors = function mapErrors(errorMap) {
+  if (!errorMap) return this;
+
+  // Only process results which have failed validation
+  if (!this.valid && this.errors) {
+    this.errors = this.errors.map(function (err) {
+      return mapError(errorMap, err);
+    });
+  }
+  return this;
+}
+
+/**
+  Maps a validation error to a custom error
+*/
+function mapError(map, err) {
+  if (!err) return err;
+
+  // Get the property path, validator type and validator sub-type from the error
+  var propPath = err.property;
+  var validatorType = err.validatorType;
+  var validatorSubType = err.validatorSubType;
+
+  // Check for a custom error for the property path
+  var msgProp = map[propPath];
+  if (!msgProp) {
+    // No custom message
+    return err;
+  }
+  if (typeof msgProp === 'string') {
+    // Only a single message for this property
+    err.message = msgProp;
+    return err;
+  }
+
+  // Check for a custom error for the validator type
+  var valProp = validatorType ? msgProp[validatorType] : null;
+  if (!valProp) {
+    // No custom validator message
+    err.message = msgProp.message || err.message;
+    return err;
+  }
+  if (typeof valProp === 'string') {
+    // Only a single message for this validator
+    err.message = valProp;
+    return err;
+  }
+
+  // Check for a custom error for the validator sub-type
+  var subValProp = validatorSubType ? valProp[validatorSubType] : null;
+  if (!subValProp) {
+    err.message = valProp.message || err.message;
+    return err;
+  }
+
+  err.message = subValProp;
+  return err;
+}
+
 Object.defineProperty(ValidatorResult.prototype, "valid", { get: function() {
 	return !this.errors.length;
 } });

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -105,8 +105,21 @@ function mapError(map, err) {
   var validatorType = err.validatorType;
   var validatorSubType = err.validatorSubType;
 
+  if (!propPath) return err;
+
+  // Replace all array indexers
+  var altPropPath = propPath.replace(/\[\d+\]/g, '[]');
+
+  var msgProp;
+  if (altPropPath !== propPath) {
+    // We have array indexers present, try most
+    // specific path first, then generic one
+    msgProp = map[propPath] || map[altPropPath];
+  } else {
+    msgProp = map[propPath];
+  }
+
   // Check for a custom error for the property path
-  var msgProp = propPath ? map[propPath] : null;
   if (!msgProp) {
     // No custom message
     return err;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -34,8 +34,15 @@ var ValidatorResult = exports.ValidatorResult = function ValidatorResult(instanc
   this.throwError = options && options.throwError;
 };
 
-ValidatorResult.prototype.addError = function addError(message, validatorName) {
-  var err = new ValidationError(message, this.instance, this.schema, this.propertyPath, validatorName);
+ValidatorResult.prototype.addError = function addError(detail) {
+  if (typeof detail == 'string') throw new Error('string error not supported');
+  if (!detail) throw new Error('Missing error detail');
+  if (!detail.message) throw new Error('Missing error message');
+  if (!detail.validatorType) throw new Error('Missing validator type');
+
+  var err = new ValidationError(detail.message, this.instance, this.schema, this.propertyPath);
+  err.validatorType = detail.validatorType;
+  err.validatorSubType = detail.validatorSubType || void 0;
   if (this.throwError) {
     throw err;
   }
@@ -44,15 +51,16 @@ ValidatorResult.prototype.addError = function addError(message, validatorName) {
 };
 
 ValidatorResult.prototype.importErrors = function importErrors(res) {
-	if (typeof res == 'string') {
-		throw new Error('string error type not supported');
-	}
-	if (res && res.errors) {
-		var errs = this.errors;
-		res.errors.forEach(function (v) {
-			errs.push(v);
-		});
-}
+  if (typeof res == 'string') throw new Error('string error type not supported');
+  if (res.validatorType) {
+    // Straight error
+    errs.push(res);
+  } else if (res && res.errors) {
+    var errs = this.errors;
+    res.errors.forEach(function (v) {
+      errs.push(v);
+    });
+  }
 };
 
 ValidatorResult.prototype.toString = function toString(res) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -2,7 +2,7 @@
 
 var uri = require('url');
 
-var ValidationError = exports.ValidationError = function ValidationError (message, instance, schema, propertyPath) {
+var ValidationError = exports.ValidationError = function ValidationError (message, instance, schema, propertyPath, validatorType, validatorSubType) {
   if (propertyPath) {
     this.property = propertyPath;
   }
@@ -19,6 +19,8 @@ var ValidationError = exports.ValidationError = function ValidationError (messag
   if (instance) {
     this.instance = instance;
   }
+  this.validatorType = validatorType;
+  this.validatorSubType = validatorSubType;
   this.stack = this.toString();
 };
 
@@ -35,14 +37,16 @@ var ValidatorResult = exports.ValidatorResult = function ValidatorResult(instanc
 };
 
 ValidatorResult.prototype.addError = function addError(detail) {
-  if (typeof detail == 'string') throw new Error('string error not supported');
-  if (!detail) throw new Error('Missing error detail');
-  if (!detail.message) throw new Error('Missing error message');
-  if (!detail.validatorType) throw new Error('Missing validator type');
+  var err;
+  if (typeof detail == 'string') {
+    err = new ValidationError(detail, this.instance, this.schema, this.propertyPath);
+  } else {
+    if (!detail) throw new Error('Missing error detail');
+    if (!detail.message) throw new Error('Missing error message');
+    if (!detail.validatorType) throw new Error('Missing validator type');
+    err = new ValidationError(detail.message, this.instance, this.schema, this.propertyPath, detail.validatorType, detail.validatorSubType);
+  }
 
-  var err = new ValidationError(detail.message, this.instance, this.schema, this.propertyPath);
-  err.validatorType = detail.validatorType;
-  err.validatorSubType = detail.validatorSubType || void 0;
   if (this.throwError) {
     throw err;
   }
@@ -51,10 +55,8 @@ ValidatorResult.prototype.addError = function addError(detail) {
 };
 
 ValidatorResult.prototype.importErrors = function importErrors(res) {
-  if (typeof res == 'string') throw new Error('string error type not supported');
-  if (res.validatorType) {
-    // Straight error
-    errs.push(res);
+  if (typeof res == 'string' || (res && res.validatorType)) {
+    this.addError(res);
   } else if (res && res.errors) {
     var errs = this.errors;
     res.errors.forEach(function (v) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -34,8 +34,8 @@ var ValidatorResult = exports.ValidatorResult = function ValidatorResult(instanc
   this.throwError = options && options.throwError;
 };
 
-ValidatorResult.prototype.addError = function addError(message) {
-  var err = new ValidationError(message, this.instance, this.schema, this.propertyPath);
+ValidatorResult.prototype.addError = function addError(message, validatorName) {
+  var err = new ValidationError(message, this.instance, this.schema, this.propertyPath, validatorName);
   if (this.throwError) {
     throw err;
   }
@@ -44,14 +44,15 @@ ValidatorResult.prototype.addError = function addError(message) {
 };
 
 ValidatorResult.prototype.importErrors = function importErrors(res) {
-  if (typeof res == 'string') {
-    this.addError(res);
-  } else if (res && res.errors) {
-    var errs = this.errors;
-    res.errors.forEach(function (v) {
-      errs.push(v)
-    });
-  }
+	if (typeof res == 'string') {
+		throw new Error('string error type not supported');
+	}
+	if (res && res.errors) {
+		var errs = this.errors;
+		res.errors.forEach(function (v) {
+			errs.push(v);
+		});
+}
 };
 
 ValidatorResult.prototype.toString = function toString(res) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -77,9 +77,17 @@ ValidatorResult.prototype.mapErrors = function mapErrors(errorMap) {
 
   // Only process results which have failed validation
   if (!this.valid && this.errors) {
-    this.errors = this.errors.map(function (err) {
-      return mapError(errorMap, err);
-    });
+    // Allow custom mapping function instead of error map
+    if (typeof errorMap === 'function') {
+      this.errors = this.errors.map(function (err) {
+        return errorMap(err);
+      });
+    }
+    else {
+      this.errors = this.errors.map(function (err) {
+        return mapError(errorMap, err);
+      });
+    }
   }
   return this;
 }
@@ -98,7 +106,7 @@ function mapError(map, err) {
   var validatorSubType = err.validatorSubType;
 
   // Check for a custom error for the property path
-  var msgProp = map[propPath];
+  var msgProp = propPath ? map[propPath] : null;
   if (!msgProp) {
     // No custom message
     return err;

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -217,16 +217,6 @@ Validator.prototype.validateSchema = function validateSchema (instance, schema, 
         throw new SchemaError("Unsupported attribute: " + key, schema);
       }
       if (validatorErr) {
-        if (typeof validatorErr == 'string') {
-          var msg = validatorErr;
-          validatorErr = new ValidatorResult(instance, schema, options, ctx);
-          validatorErr.addError(msg);
-        }
-        if (validatorErr.errors) {
-          validatorErr.errors.forEach(function (v) {
-            v.validatorName = key;
-          });
-        }
         result.importErrors(validatorErr);
       }
     }

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -217,6 +217,16 @@ Validator.prototype.validateSchema = function validateSchema (instance, schema, 
         throw new SchemaError("Unsupported attribute: " + key, schema);
       }
       if (validatorErr) {
+        if (typeof validatorErr == 'string') {
+          var msg = validatorErr;
+          validatorErr = new ValidatorResult(instance, schema, options, ctx);
+          validatorErr.addError(msg);
+        }
+        if (validatorErr.errors) {
+          validatorErr.errors.forEach(function (v) {
+            v.validatorName = key;
+          });
+        }
         result.importErrors(validatorErr);
       }
     }

--- a/test/i18n.js
+++ b/test/i18n.js
@@ -54,6 +54,14 @@ describe('i18n', function () {
     });
 
     describe('type', function () {
+
+      it('should handle multiple types', function () {
+        //NOTE: Not sure this is the correct way to handle this scenario...
+        this.validator.validate('not-number', { type: ['number', 'null'] }).mapErrors({
+          'instance': 'Custom error message'
+        }).errors[0].validatorSubType.should.equal('null,number');
+      });
+
       describe('number', function () {
 
         it('should provide custom error message for property', function () {

--- a/test/i18n.js
+++ b/test/i18n.js
@@ -55,13 +55,6 @@ describe('i18n', function () {
 
     describe('type', function () {
 
-      it('should handle multiple types', function () {
-        //NOTE: Not sure this is the correct way to handle this scenario...
-        this.validator.validate('not-number', { type: ['number', 'null'] }).mapErrors({
-          'instance': 'Custom error message'
-        }).errors[0].validatorSubType.should.equal('null,number');
-      });
-
       describe('number', function () {
 
         it('should provide custom error message for property', function () {
@@ -78,24 +71,14 @@ describe('i18n', function () {
           }).errors[0].message.should.equal('Custom error message');
         });
 
-        it('should provide custom error message for validator sub-type', function () {
-          this.validator.validate('not-number', {'type': 'number'}).mapErrors({
-            'instance': {
-              'type': {
-                'number': 'Custom error message'
-              }
-            }
-          }).errors[0].message.should.equal('Custom error message');
-        });
-
         it('should provide a validator type', function () {
           this.validator.validate('not-number', {'type': 'number'}).mapErrors({
           }).errors[0].validatorType.should.equal('type');
         });
 
-        it('should provide a validator sub-type', function () {
-          this.validator.validate('not-number', {'type': 'number'}).mapErrors({
-          }).errors[0].validatorSubType.should.equal('number');
+        it('should not provide a validator sub-type', function () {
+          should.not.exist(this.validator.validate('not-number', {'type': 'number'}).mapErrors({
+          }).errors[0].validatorSubType);
         });
 
       });
@@ -144,24 +127,14 @@ describe('i18n', function () {
           }).errors[0].message.should.equal('Custom error message');
         });
 
-        it('should provide custom error message for validator sub-type', function () {
-          this.validator.validate('0', {'type': 'null'}).mapErrors({
-            'instance': {
-              'type': {
-                'null': 'Custom error message'
-              }
-            }
-          }).errors[0].message.should.equal('Custom error message');
-        });
-
         it('should provide a validator type', function () {
           this.validator.validate('0', {'type': 'null'}).mapErrors({
           }).errors[0].validatorType.should.equal('type');
         });
 
-        it('should provide a validator sub-type', function () {
-          this.validator.validate('0', {'type': 'null'}).mapErrors({
-          }).errors[0].validatorSubType.should.equal('null');
+        it('should not provide a validator sub-type', function () {
+          should.not.exist(this.validator.validate('0', {'type': 'null'}).mapErrors({
+          }).errors[0].validatorSubType);
         });
 
       });
@@ -182,24 +155,14 @@ describe('i18n', function () {
           }).errors[0].message.should.equal('Custom error message');
         });
 
-        it('should provide custom error message for validator sub-type', function () {
-          this.validator.validate('0', {'type': 'date'}).mapErrors({
-            'instance': {
-              'type': {
-                'date': 'Custom error message'
-              }
-            }
-          }).errors[0].message.should.equal('Custom error message');
-        });
-
         it('should provide a validator type', function () {
           this.validator.validate('0', {'type': 'date'}).mapErrors({
           }).errors[0].validatorType.should.equal('type');
         });
 
-        it('should provide a validator sub-type', function () {
-          this.validator.validate('0', {'type': 'date'}).mapErrors({
-          }).errors[0].validatorSubType.should.equal('date');
+        it('should not provide a validator sub-type', function () {
+          should.not.exist(this.validator.validate('0', {'type': 'date'}).mapErrors({
+          }).errors[0].validatorSubType);
         });
 
       });
@@ -220,24 +183,14 @@ describe('i18n', function () {
           }).errors[0].message.should.equal('Custom error message');
         });
 
-        it('should provide custom error message for validator sub-type', function () {
-          this.validator.validate(0.25, {'type': 'integer'}).mapErrors({
-            'instance': {
-              'type': {
-                'integer': 'Custom error message'
-              }
-            }
-          }).errors[0].message.should.equal('Custom error message');
-        });
-
         it('should provide a validator type', function () {
           this.validator.validate(0.25, {'type': 'integer'}).mapErrors({
           }).errors[0].validatorType.should.equal('type');
         });
 
-        it('should provide a validator sub-type', function () {
-          this.validator.validate(0.25, {'type': 'integer'}).mapErrors({
-          }).errors[0].validatorSubType.should.equal('integer');
+        it('should not provide a validator sub-type', function () {
+          should.not.exist(this.validator.validate(0.25, {'type': 'integer'}).mapErrors({
+          }).errors[0].validatorSubType);
         });
 
       });
@@ -258,24 +211,14 @@ describe('i18n', function () {
           }).errors[0].message.should.equal('Custom error message');
         });
 
-        it('should provide custom error message for validator sub-type', function () {
-          this.validator.validate('true', {'type': 'boolean'}).mapErrors({
-            'instance': {
-              'type': {
-                'boolean': 'Custom error message'
-              }
-            }
-          }).errors[0].message.should.equal('Custom error message');
-        });
-
         it('should provide a validator type', function () {
           this.validator.validate('true', {'type': 'boolean'}).mapErrors({
           }).errors[0].validatorType.should.equal('type');
         });
 
-        it('should provide a validator sub-type', function () {
-          this.validator.validate('true', {'type': 'boolean'}).mapErrors({
-          }).errors[0].validatorSubType.should.equal('boolean');
+        it('should not provide a validator sub-type', function () {
+          should.not.exist(this.validator.validate('true', {'type': 'boolean'}).mapErrors({
+          }).errors[0].validatorSubType);
         });
 
       });
@@ -1253,24 +1196,14 @@ describe('i18n', function () {
         }).errors[0].message.should.equal('Custom error message');
       });
 
-      it('should provide custom error message for validator sub-type', function () {
-        this.validator.validate(0, {'type': 'array'}).mapErrors({
-          'instance': {
-            'type': {
-              'array': 'Custom error message'
-            }
-          }
-        }).errors[0].message.should.equal('Custom error message');
-      });
-
       it('should provide a validator type', function () {
         this.validator.validate(0, {'type': 'array'}).mapErrors({
         }).errors[0].validatorType.should.equal('type');
       });
 
-      it('should provide a validator sub-type', function () {
-        this.validator.validate(0, {'type': 'array'}).mapErrors({
-        }).errors[0].validatorSubType.should.equal('array');
+      it('should not provide a validator sub-type', function () {
+        should.not.exist(this.validator.validate(0, {'type': 'array'}).mapErrors({
+        }).errors[0].validatorSubType);
       });
 
       describe('attribute on array items', function () {
@@ -1289,10 +1222,10 @@ describe('i18n', function () {
         });
 
         it('should provide custom error message for validator sub-type', function () {
-          this.validator.validate(['1', '2', '3', 4], {'type': 'array', 'items': {'type': 'string'}}).mapErrors({
+          this.validator.validate(['1', '2', '3', '4$'], {'type': 'array', 'items': {'type': 'string', 'format': 'alphanumeric'}}).mapErrors({
             'instance[]': {
-              'type': {
-                'string': 'Custom error message'
+              'format': {
+                'alphanumeric': 'Custom error message'
               }
             }
           }).errors[0].message.should.equal('Custom error message');
@@ -1304,8 +1237,8 @@ describe('i18n', function () {
         });
 
         it('should provide a validator sub-type', function () {
-          this.validator.validate(['1', '2', '3', 4], {'type': 'array', 'items': {'type': 'string'}}).mapErrors({
-          }).errors[0].validatorSubType.should.equal('string');
+          this.validator.validate(['1', '2', '3', '4$'], {'type': 'array', 'items': {'type': 'string', 'format': 'alphanumeric'}}).mapErrors({
+          }).errors[0].validatorSubType.should.equal('alphanumeric');
         });
 
         it('should provide custom error message for specific array item', function () {
@@ -1415,7 +1348,7 @@ describe('i18n', function () {
           'name': {'type': 'string'},
           'lines': {
             'type': 'array',
-            'items': {'type': 'string'}
+            'items': {'type': 'string', 'format': 'alphanumeric'}
           }
         }
       };
@@ -1423,47 +1356,47 @@ describe('i18n', function () {
 
     describe('simple object with array with invalid items', function () {
       it('should provide custom error message for property', function () {
-        this.validator.validate({'name':'test', 'lines': [1]},this.mixedSchema).mapErrors({
+        this.validator.validate({'name':'test', 'lines': ['1$']},this.mixedSchema).mapErrors({
           'instance.lines[]': 'Custom error message'
         }).errors[0].message.should.equal('Custom error message');
       });
 
       it('should provide custom error message for validator type', function () {
-        this.validator.validate({'name':'test', 'lines': [1]},this.mixedSchema).mapErrors({
+        this.validator.validate({'name':'test', 'lines': ['1$']},this.mixedSchema).mapErrors({
           'instance.lines[]': {
-            'type': 'Custom error message'
+            'format': 'Custom error message'
           }
         }).errors[0].message.should.equal('Custom error message');
       });
 
       it('should provide custom error message for validator sub-type', function () {
-        this.validator.validate({'name':'test', 'lines': [1]},this.mixedSchema).mapErrors({
+        this.validator.validate({'name':'test', 'lines': ['1$']},this.mixedSchema).mapErrors({
           'instance.lines[]': {
-            'type': {
-              'string': 'Custom error message'
+            'format': {
+              'alphanumeric': 'Custom error message'
             }
           }
         }).errors[0].message.should.equal('Custom error message');
       });
 
       it('should provide a validator type', function () {
-        this.validator.validate({'name':'test', 'lines': [1]},this.mixedSchema).mapErrors({
+        this.validator.validate({'name':'test', 'lines': ['1$']},this.mixedSchema).mapErrors({
           'instance.lines[]': {
-            'type': {
-              'string': 'Custom error message'
+            'format': {
+              'alphanumeric': 'Custom error message'
             }
           }
-        }).errors[0].validatorType.should.equal('type');
+        }).errors[0].validatorType.should.equal('format');
       });
 
       it('should provide a validator sub-type', function () {
-        this.validator.validate({'name':'test', 'lines': [1]},this.mixedSchema).mapErrors({
+        this.validator.validate({'name':'test', 'lines': ['1$']},this.mixedSchema).mapErrors({
           'instance.lines[]': {
-            'type': {
-              'string': 'Custom error message'
+            'format': {
+              'alphanumeric': 'Custom error message'
             }
           }
-        }).errors[0].validatorSubType.should.equal('string');
+        }).errors[0].validatorSubType.should.equal('alphanumeric');
       });
     });
   });

--- a/test/i18n.js
+++ b/test/i18n.js
@@ -1,0 +1,1463 @@
+'use strict';
+
+/*jsl predef:define*/
+/*jsl predef:it*/
+
+var Validator = require('../lib/validator');
+var should = require('chai').should();
+
+describe('i18n', function () {
+  beforeEach(function () {
+    this.validator = new Validator();
+  });
+
+  it('should override message from previous mapErrors if defined', function () {
+    var r = this.validator.validate({
+      a: 'not-number',
+      b: 'not-number'
+    }, {
+      'type': 'object',
+      'properties': {
+        a: { 'type': 'number'},
+        b: { 'type': 'number'}
+      }
+    }).mapErrors({ 'instance.a': 'Custom error message A' })
+      .mapErrors({
+        'instance.a': 'Custom error message A2',
+        'instance.b': 'Custom error message B'
+      });
+
+    r.errors[0].message.should.equal('Custom error message A2');
+    r.errors[1].message.should.equal('Custom error message B');
+  });
+
+  it('should keep existing message from previous mapErrors if not defined', function () {
+    var r = this.validator.validate({
+      a: 'not-number',
+      b: 'not-number'
+    }, {
+      'type': 'object',
+      'properties': {
+        a: { 'type': 'number'},
+        b: { 'type': 'number'}
+      }
+    }).mapErrors({ 'instance.a': 'Custom error message A' })
+      .mapErrors({ 'instance.b': 'Custom error message B' });
+
+    r.errors[0].message.should.equal('Custom error message A');
+    r.errors[1].message.should.equal('Custom error message B');
+  });
+
+  describe('attributes', function () {
+    beforeEach(function () {
+      this.validator = new Validator();
+    });
+
+    describe('type', function () {
+      describe('number', function () {
+
+        it('should provide custom error message for property', function () {
+          this.validator.validate('not-number', {'type': 'number'}).mapErrors({
+            'instance': 'Custom error message'
+          }).errors[0].message.should.equal('Custom error message');
+        });
+
+        it('should provide custom error message for validator type', function () {
+          this.validator.validate('not-number', {'type': 'number'}).mapErrors({
+            'instance': {
+              'type': 'Custom error message'
+            }
+          }).errors[0].message.should.equal('Custom error message');
+        });
+
+        it('should provide custom error message for validator sub-type', function () {
+          this.validator.validate('not-number', {'type': 'number'}).mapErrors({
+            'instance': {
+              'type': {
+                'number': 'Custom error message'
+              }
+            }
+          }).errors[0].message.should.equal('Custom error message');
+        });
+
+        it('should provide a validator type', function () {
+          this.validator.validate('not-number', {'type': 'number'}).mapErrors({
+          }).errors[0].validatorType.should.equal('type');
+        });
+
+        it('should provide a validator sub-type', function () {
+          this.validator.validate('not-number', {'type': 'number'}).mapErrors({
+          }).errors[0].validatorSubType.should.equal('number');
+        });
+
+      });
+
+      describe('required', function () {
+
+        it('should provide custom error message for property', function () {
+          this.validator.validate(undefined, {'type': 'number', 'required': true}).mapErrors({
+            'instance': 'Custom error message'
+          }).errors[0].message.should.equal('Custom error message');
+        });
+
+        it('should provide custom error message for validator type', function () {
+          this.validator.validate(undefined, {'type': 'number', 'required': true}).mapErrors({
+            'instance': {
+              'required': 'Custom error message'
+            }
+          }).errors[0].message.should.equal('Custom error message');
+        });
+
+        it('should provide a validator type', function () {
+          this.validator.validate(undefined, {'type': 'number', 'required': true}).mapErrors({
+          }).errors[0].validatorType.should.equal('required');
+        });
+
+        it('should not provide a validator sub-type', function () {
+          should.not.exist(this.validator.validate(undefined, {'type': 'number', 'required': true}).mapErrors({
+          }).errors[0].validatorSubType);
+        });
+
+      });
+
+      describe('null', function () {
+
+        it('should provide custom error message for property', function () {
+          this.validator.validate('0', {'type': 'null'}).mapErrors({
+            'instance': 'Custom error message'
+          }).errors[0].message.should.equal('Custom error message');
+        });
+
+        it('should provide custom error message for validator type', function () {
+          this.validator.validate('0', {'type': 'null'}).mapErrors({
+            'instance': {
+              'type': 'Custom error message'
+            }
+          }).errors[0].message.should.equal('Custom error message');
+        });
+
+        it('should provide custom error message for validator sub-type', function () {
+          this.validator.validate('0', {'type': 'null'}).mapErrors({
+            'instance': {
+              'type': {
+                'null': 'Custom error message'
+              }
+            }
+          }).errors[0].message.should.equal('Custom error message');
+        });
+
+        it('should provide a validator type', function () {
+          this.validator.validate('0', {'type': 'null'}).mapErrors({
+          }).errors[0].validatorType.should.equal('type');
+        });
+
+        it('should provide a validator sub-type', function () {
+          this.validator.validate('0', {'type': 'null'}).mapErrors({
+          }).errors[0].validatorSubType.should.equal('null');
+        });
+
+      });
+
+      describe('date', function () {
+
+        it('should provide custom error message for property', function () {
+          this.validator.validate('0', {'type': 'date'}).mapErrors({
+            'instance': 'Custom error message'
+          }).errors[0].message.should.equal('Custom error message');
+        });
+
+        it('should provide custom error message for validator type', function () {
+          this.validator.validate('0', {'type': 'date'}).mapErrors({
+            'instance': {
+              'type': 'Custom error message'
+            }
+          }).errors[0].message.should.equal('Custom error message');
+        });
+
+        it('should provide custom error message for validator sub-type', function () {
+          this.validator.validate('0', {'type': 'date'}).mapErrors({
+            'instance': {
+              'type': {
+                'date': 'Custom error message'
+              }
+            }
+          }).errors[0].message.should.equal('Custom error message');
+        });
+
+        it('should provide a validator type', function () {
+          this.validator.validate('0', {'type': 'date'}).mapErrors({
+          }).errors[0].validatorType.should.equal('type');
+        });
+
+        it('should provide a validator sub-type', function () {
+          this.validator.validate('0', {'type': 'date'}).mapErrors({
+          }).errors[0].validatorSubType.should.equal('date');
+        });
+
+      });
+
+      describe('integer', function () {
+
+        it('should provide custom error message for property', function () {
+          this.validator.validate(0.25, {'type': 'integer'}).mapErrors({
+            'instance': 'Custom error message'
+          }).errors[0].message.should.equal('Custom error message');
+        });
+
+        it('should provide custom error message for validator type', function () {
+          this.validator.validate(0.25, {'type': 'integer'}).mapErrors({
+            'instance': {
+              'type': 'Custom error message'
+            }
+          }).errors[0].message.should.equal('Custom error message');
+        });
+
+        it('should provide custom error message for validator sub-type', function () {
+          this.validator.validate(0.25, {'type': 'integer'}).mapErrors({
+            'instance': {
+              'type': {
+                'integer': 'Custom error message'
+              }
+            }
+          }).errors[0].message.should.equal('Custom error message');
+        });
+
+        it('should provide a validator type', function () {
+          this.validator.validate(0.25, {'type': 'integer'}).mapErrors({
+          }).errors[0].validatorType.should.equal('type');
+        });
+
+        it('should provide a validator sub-type', function () {
+          this.validator.validate(0.25, {'type': 'integer'}).mapErrors({
+          }).errors[0].validatorSubType.should.equal('integer');
+        });
+
+      });
+
+      describe('boolean', function () {
+
+        it('should provide custom error message for property', function () {
+          this.validator.validate('true', {'type': 'boolean'}).mapErrors({
+            'instance': 'Custom error message'
+          }).errors[0].message.should.equal('Custom error message');
+        });
+
+        it('should provide custom error message for validator type', function () {
+          this.validator.validate('true', {'type': 'boolean'}).mapErrors({
+            'instance': {
+              'type': 'Custom error message'
+            }
+          }).errors[0].message.should.equal('Custom error message');
+        });
+
+        it('should provide custom error message for validator sub-type', function () {
+          this.validator.validate('true', {'type': 'boolean'}).mapErrors({
+            'instance': {
+              'type': {
+                'boolean': 'Custom error message'
+              }
+            }
+          }).errors[0].message.should.equal('Custom error message');
+        });
+
+        it('should provide a validator type', function () {
+          this.validator.validate('true', {'type': 'boolean'}).mapErrors({
+          }).errors[0].validatorType.should.equal('type');
+        });
+
+        it('should provide a validator sub-type', function () {
+          this.validator.validate('true', {'type': 'boolean'}).mapErrors({
+          }).errors[0].validatorSubType.should.equal('boolean');
+        });
+
+      });
+
+      describe('any', function () {
+
+        //NOTE: Because any will let through everything, the custom message must go on the required attribute
+
+        it('should provide custom error message for property', function () {
+          this.validator.validate(undefined, {'type': 'any', required: true}).mapErrors({
+            'instance': 'Custom error message'
+          }).errors[0].message.should.equal('Custom error message');
+        });
+
+        it('should provide custom error message for validator type', function () {
+          this.validator.validate(undefined, {'type': 'any', required: true}).mapErrors({
+            'instance': {
+              'required': 'Custom error message'
+            }
+          }).errors[0].message.should.equal('Custom error message');
+        });
+
+        it('should provide a validator type', function () {
+          this.validator.validate(undefined, {'type': 'any', required: true}).mapErrors({
+          }).errors[0].validatorType.should.equal('required');
+        });
+
+        it('should not provide a validator sub-type', function () {
+          should.not.exist(this.validator.validate(undefined, {'type': 'any', required: true}).mapErrors({
+          }).errors[0].validatorSubType);
+        });
+
+      });
+    });
+
+    describe('minimum', function () {
+
+      it('should provide custom error message for property', function () {
+        this.validator.validate(1, {'type': 'number', 'minimum': 2}).mapErrors({
+          'instance': 'Custom error message'
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator type', function () {
+        this.validator.validate(1, {'type': 'number', 'minimum': 2}).mapErrors({
+          'instance': {
+            'minimum': 'Custom error message'
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide a validator type', function () {
+        this.validator.validate(1, {'type': 'number', 'minimum': 2}).mapErrors({
+        }).errors[0].validatorType.should.equal('minimum');
+      });
+
+      it('should not provide a validator sub-type', function () {
+        should.not.exist(this.validator.validate(1, {'type': 'number', 'minimum': 2}).mapErrors({
+        }).errors[0].validatorSubType);
+      });
+
+      describe('exclusiveMinimum', function () {
+
+        it('should provide custom error message for property', function () {
+          this.validator.validate(1, {'type': 'number', 'minimum': 1, 'exclusiveMinimum': true}).mapErrors({
+            'instance': 'Custom error message'
+          }).errors[0].message.should.equal('Custom error message');
+        });
+
+        it('should provide custom error message for validator type', function () {
+          this.validator.validate(1, {'type': 'number', 'minimum': 1, 'exclusiveMinimum': true}).mapErrors({
+            'instance': {
+              'minimum': 'Custom error message'
+            }
+          }).errors[0].message.should.equal('Custom error message');
+        });
+
+        it('should provide a validator type', function () {
+          this.validator.validate(1, {'type': 'number', 'minimum': 1, 'exclusiveMinimum': true}).mapErrors({
+          }).errors[0].validatorType.should.equal('minimum');
+        });
+
+        it('should not provide a validator sub-type', function () {
+          should.not.exist(this.validator.validate(1, {'type': 'number', 'minimum': 1, 'exclusiveMinimum': true}).mapErrors({
+          }).errors[0].validatorSubType);
+        });
+
+      });
+
+    });
+
+    describe('maximum', function () {
+      it('should provide custom error message for property', function () {
+        this.validator.validate(3, {'type': 'number', 'maximum': 2}).mapErrors({
+          'instance': 'Custom error message'
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator type', function () {
+        this.validator.validate(3, {'type': 'number', 'maximum': 2}).mapErrors({
+          'instance': {
+            'maximum': 'Custom error message'
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide a validator type', function () {
+        this.validator.validate(3, {'type': 'number', 'maximum': 1}).mapErrors({
+        }).errors[0].validatorType.should.equal('maximum');
+      });
+
+      it('should not provide a validator sub-type', function () {
+        should.not.exist(this.validator.validate(3, {'type': 'number', 'maximum': 1}).mapErrors({
+        }).errors[0].validatorSubType);
+      });
+
+      describe('exclusiveMaximum', function () {
+
+        it('should provide custom error message for property', function () {
+          this.validator.validate(2, {'type': 'number', 'maximum': 1, 'exclusiveMaximum': true}).mapErrors({
+            'instance': 'Custom error message'
+          }).errors[0].message.should.equal('Custom error message');
+        });
+
+        it('should provide custom error message for validator type', function () {
+          this.validator.validate(2, {'type': 'number', 'maximum': 1, 'exclusiveMaximum': true}).mapErrors({
+            'instance': {
+              'maximum': 'Custom error message'
+            }
+          }).errors[0].message.should.equal('Custom error message');
+        });
+
+        it('should provide a validator type', function () {
+          this.validator.validate(2, {'type': 'number', 'maximum': 1, 'exclusiveMaximum': true}).mapErrors({
+          }).errors[0].validatorType.should.equal('maximum');
+        });
+
+        it('should not provide a validator sub-type', function () {
+          should.not.exist(this.validator.validate(2, {'type': 'number', 'maximum': 1, 'exclusiveMaximum': true}).mapErrors({
+          }).errors[0].validatorSubType);
+        });
+
+      });
+
+    });
+
+    describe('divisibleBy', function () {
+
+      it('should provide custom error message for property', function () {
+        this.validator.validate(1, {'type': 'number', 'divisibleBy': 2}).mapErrors({
+          'instance': 'Custom error message'
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator type', function () {
+        this.validator.validate(1, {'type': 'number', 'divisibleBy': 2}).mapErrors({
+          'instance': {
+            'divisibleBy': 'Custom error message'
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide a validator type', function () {
+        this.validator.validate(1, {'type': 'number', 'divisibleBy': 2}).mapErrors({
+        }).errors[0].validatorType.should.equal('divisibleBy');
+      });
+
+      it('should not provide a validator sub-type', function () {
+        should.not.exist(this.validator.validate(1, {'type': 'number', 'divisibleBy': 2}).mapErrors({
+        }).errors[0].validatorSubType);
+      });
+
+    });
+
+    describe('pattern', function () {
+
+      it('should provide custom error message for property', function () {
+        this.validator.validate('abac', {'type': 'string', 'pattern': 'ab+c'}).mapErrors({
+          'instance': 'Custom error message'
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator type', function () {
+        this.validator.validate('abac', {'type': 'string', 'pattern': 'ab+c'}).mapErrors({
+          'instance': {
+            'pattern': 'Custom error message'
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide a validator type', function () {
+        this.validator.validate('abac', {'type': 'string', 'pattern': 'ab+c'}).mapErrors({
+        }).errors[0].validatorType.should.equal('pattern');
+      });
+
+      it('should not provide a validator sub-type', function () {
+        should.not.exist(this.validator.validate('abac', {'type': 'string', 'pattern': 'ab+c'}).mapErrors({
+        }).errors[0].validatorSubType);
+      });
+
+    });
+
+    describe('minLength', function () {
+
+      it('should provide custom error message for property', function () {
+        this.validator.validate('abcde', {'type': 'string', 'minLength': 6}).mapErrors({
+          'instance': 'Custom error message'
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator type', function () {
+        this.validator.validate('abcde', {'type': 'string', 'minLength': 6}).mapErrors({
+          'instance': {
+            'minLength': 'Custom error message'
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide a validator type', function () {
+        this.validator.validate('abcde', {'type': 'string', 'minLength': 6}).mapErrors({
+        }).errors[0].validatorType.should.equal('minLength');
+      });
+
+      it('should not provide a validator sub-type', function () {
+        should.not.exist(this.validator.validate('abcde', {'type': 'string', 'minLength': 6}).mapErrors({
+        }).errors[0].validatorSubType);
+      });
+
+    });
+
+    describe('maxLength', function () {
+
+      it('should provide custom error message for property', function () {
+        this.validator.validate('abcde', {'type': 'string', 'maxLength': 4}).mapErrors({
+          'instance': 'Custom error message'
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator type', function () {
+        this.validator.validate('abcde', {'type': 'string', 'maxLength': 4}).mapErrors({
+          'instance': {
+            'maxLength': 'Custom error message'
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide a validator type', function () {
+        this.validator.validate('abcde', {'type': 'string', 'maxLength': 4}).mapErrors({
+        }).errors[0].validatorType.should.equal('maxLength');
+      });
+
+      it('should not provide a validator sub-type', function () {
+        should.not.exist(this.validator.validate('abcde', {'type': 'string', 'maxLength': 4}).mapErrors({
+        }).errors[0].validatorSubType);
+      });
+
+    });
+
+    describe('enum', function () {
+
+      it('should provide custom error message for property', function () {
+        this.validator.validate('abcde', {'type': 'string', 'enum': ['abcdf', 'abcdd']}).mapErrors({
+          'instance': 'Custom error message'
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator type', function () {
+        this.validator.validate('abcde', {'type': 'string', 'enum': ['abcdf', 'abcdd']}).mapErrors({
+          'instance': {
+            'enum': 'Custom error message'
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide a validator type', function () {
+        this.validator.validate('abcde', {'type': 'string', 'enum': ['abcdf', 'abcdd']}).mapErrors({
+        }).errors[0].validatorType.should.equal('enum');
+      });
+
+      it('should not provide a validator sub-type', function () {
+        should.not.exist(this.validator.validate('abcde', {'type': 'string', 'enum': ['abcdf', 'abcdd']}).mapErrors({
+        }).errors[0].validatorSubType);
+      });
+
+    });
+
+    describe('not', function () {
+
+      it('should provide custom error message for property', function () {
+        this.validator.validate([1], {'type': 'any', 'not':'array'}).mapErrors({
+          'instance': 'Custom error message'
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator type', function () {
+        this.validator.validate([1], {'type': 'any', 'not':'array'}).mapErrors({
+          'instance': {
+            'not': 'Custom error message'
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide a validator type', function () {
+        this.validator.validate([1], {'type': 'any', 'not':'array'}).mapErrors({
+        }).errors[0].validatorType.should.equal('not');
+      });
+
+      it('should not provide a validator sub-type', function () {
+        should.not.exist(this.validator.validate([1], {'type': 'any', 'not':'array'}).mapErrors({
+        }).errors[0].validatorSubType);
+      });
+
+      it('should prohibit specified types', function () {
+        this.validator.validate([1], {'type': 'any', 'not':'array'}).valid.should.be.false;
+      });
+    });
+
+    describe('disallow', function () {
+
+      //NOTE: 'disallow' is a depreciated alias for 'not', custom error message will always use 'not' field
+
+      it('should provide custom error message for property', function () {
+        this.validator.validate([1], {'type': 'any', 'disallow':'array'}).mapErrors({
+          'instance': 'Custom error message'
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator type', function () {
+        this.validator.validate([1], {'type': 'any', 'disallow':'array'}).mapErrors({
+          'instance': {
+            'not': 'Custom error message'
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide a validator type', function () {
+        this.validator.validate([1], {'type': 'any', 'disallow':'array'}).mapErrors({
+        }).errors[0].validatorType.should.equal('not');
+      });
+
+      it('should not provide a validator sub-type', function () {
+        should.not.exist(this.validator.validate([1], {'type': 'any', 'disallow':'array'}).mapErrors({
+        }).errors[0].validatorSubType);
+      });
+
+      it('should prohibit specified types', function () {
+        this.validator.validate([1], {'type': 'any', 'disallow':'array'}).valid.should.be.false;
+      });
+    });
+
+    describe('dependencies', function () {
+
+      it('should provide custom error message for property', function () {
+        this.validator.validate({quux: 1, foo: 1}, {'dependencies': {'quux': ['foo', 'bar']}}).mapErrors({
+          'instance': 'Custom error message'
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator type', function () {
+        this.validator.validate({quux: 1, foo: 1}, {'dependencies': {'quux': ['foo', 'bar']}}).mapErrors({
+          'instance': {
+            'dependencies': 'Custom error message'
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide a validator type', function () {
+        this.validator.validate({quux: 1, foo: 1}, {'dependencies': {'quux': ['foo', 'bar']}}).mapErrors({
+        }).errors[0].validatorType.should.equal('dependencies');
+      });
+
+      it('should not provide a validator sub-type', function () {
+        should.not.exist(this.validator.validate({quux: 1, foo: 1}, {'dependencies': {'quux': ['foo', 'bar']}}).mapErrors({
+        }).errors[0].validatorSubType);
+      });
+
+    });
+  });
+
+  describe('Formats', function () {
+    beforeEach(function () {
+      this.validator = new Validator();
+    });
+
+    describe('date-time', function () {
+
+      it('should provide custom error message for property', function () {
+        this.validator.validate("2012-07-08", {'type': 'string', 'format': 'date-time'}).mapErrors({
+          'instance': 'Custom error message'
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator type', function () {
+        this.validator.validate("2012-07-08", {'type': 'string', 'format': 'date-time'}).mapErrors({
+          'instance': {
+            'format': 'Custom error message'
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator sub-type', function () {
+        this.validator.validate("2012-07-08", {'type': 'string', 'format': 'date-time'}).mapErrors({
+          'instance': {
+            'format': {
+              'date-time': 'Custom error message'
+            }
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide a validator type', function () {
+        this.validator.validate("2012-07-08", {'type': 'string', 'format': 'date-time'}).mapErrors({
+        }).errors[0].validatorType.should.equal('format');
+      });
+
+      it('should provide a validator sub-type', function () {
+        this.validator.validate("2012-07-08", {'type': 'string', 'format': 'date-time'}).mapErrors({
+        }).errors[0].validatorSubType.should.equal('date-time');
+      });
+
+    });
+
+    describe('date', function () {
+
+      it('should provide custom error message for property', function () {
+        this.validator.validate("TEST2012-07-08", {'type': 'string', 'format': 'date'}).mapErrors({
+          'instance': 'Custom error message'
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator type', function () {
+        this.validator.validate("TEST2012-07-08", {'type': 'string', 'format': 'date'}).mapErrors({
+          'instance': {
+            'format': 'Custom error message'
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator sub-type', function () {
+        this.validator.validate("TEST2012-07-08", {'type': 'string', 'format': 'date'}).mapErrors({
+          'instance': {
+            'format': {
+              'date': 'Custom error message'
+            }
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide a validator type', function () {
+        this.validator.validate("TEST2012-07-08", {'type': 'string', 'format': 'date'}).mapErrors({
+        }).errors[0].validatorType.should.equal('format');
+      });
+
+      it('should provide a validator sub-type', function () {
+        this.validator.validate("TEST2012-07-08", {'type': 'string', 'format': 'date'}).mapErrors({
+        }).errors[0].validatorSubType.should.equal('date');
+      });
+
+    });
+
+    describe('time', function () {
+
+      it('should provide custom error message for property', function () {
+        this.validator.validate("16:41:41.532Z", {'type': 'string', 'format': 'time'}).mapErrors({
+          'instance': 'Custom error message'
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator type', function () {
+        this.validator.validate("16:41:41.532Z", {'type': 'string', 'format': 'time'}).mapErrors({
+          'instance': {
+            'format': 'Custom error message'
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator sub-type', function () {
+        this.validator.validate("16:41:41.532Z", {'type': 'string', 'format': 'time'}).mapErrors({
+          'instance': {
+            'format': {
+              'time': 'Custom error message'
+            }
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide a validator type', function () {
+        this.validator.validate("16:41:41.532Z", {'type': 'string', 'format': 'time'}).mapErrors({
+        }).errors[0].validatorType.should.equal('format');
+      });
+
+      it('should provide a validator sub-type', function () {
+        this.validator.validate("16:41:41.532Z", {'type': 'string', 'format': 'time'}).mapErrors({
+        }).errors[0].validatorSubType.should.equal('time');
+      });
+
+    });
+
+    describe('utc-millisec', function () {
+
+      it('should provide custom error message for property', function () {
+        this.validator.validate("16:41:41.532Z", {'type': 'string', 'format': 'utc-millisec'}).mapErrors({
+          'instance': 'Custom error message'
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator type', function () {
+        this.validator.validate("16:41:41.532Z", {'type': 'string', 'format': 'utc-millisec'}).mapErrors({
+          'instance': {
+            'format': 'Custom error message'
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator sub-type', function () {
+        this.validator.validate("16:41:41.532Z", {'type': 'string', 'format': 'utc-millisec'}).mapErrors({
+          'instance': {
+            'format': {
+              'utc-millisec': 'Custom error message'
+            }
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide a validator type', function () {
+        this.validator.validate("16:41:41.532Z", {'type': 'string', 'format': 'utc-millisec'}).mapErrors({
+        }).errors[0].validatorType.should.equal('format');
+      });
+
+      it('should provide a validator sub-type', function () {
+        this.validator.validate("16:41:41.532Z", {'type': 'string', 'format': 'utc-millisec'}).mapErrors({
+        }).errors[0].validatorSubType.should.equal('utc-millisec');
+      });
+
+    });
+
+    describe('regex', function () {
+
+      it('should provide custom error message for property', function () {
+        this.validator.validate("/^(abc]/", {'type': 'string', 'format': 'regex'}).mapErrors({
+          'instance': 'Custom error message'
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator type', function () {
+        this.validator.validate("/^(abc]/", {'type': 'string', 'format': 'regex'}).mapErrors({
+          'instance': {
+            'format': 'Custom error message'
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator sub-type', function () {
+        this.validator.validate("/^(abc]/", {'type': 'string', 'format': 'regex'}).mapErrors({
+          'instance': {
+            'format': {
+              'regex': 'Custom error message'
+            }
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide a validator type', function () {
+        this.validator.validate("/^(abc]/", {'type': 'string', 'format': 'regex'}).mapErrors({
+        }).errors[0].validatorType.should.equal('format');
+      });
+
+      it('should provide a validator sub-type', function () {
+        this.validator.validate("/^(abc]/", {'type': 'string', 'format': 'regex'}).mapErrors({
+        }).errors[0].validatorSubType.should.equal('regex');
+      });
+
+    });
+
+    describe('color', function () {
+
+      it('should provide custom error message for property', function () {
+        this.validator.validate("json", {'type': 'string', 'format': 'color'}).mapErrors({
+          'instance': 'Custom error message'
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator type', function () {
+        this.validator.validate("json", {'type': 'string', 'format': 'color'}).mapErrors({
+          'instance': {
+            'format': 'Custom error message'
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator sub-type', function () {
+        this.validator.validate("json", {'type': 'string', 'format': 'color'}).mapErrors({
+          'instance': {
+            'format': {
+              'color': 'Custom error message'
+            }
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide a validator type', function () {
+        this.validator.validate("json", {'type': 'string', 'format': 'color'}).mapErrors({
+        }).errors[0].validatorType.should.equal('format');
+      });
+
+      it('should provide a validator sub-type', function () {
+        this.validator.validate("json", {'type': 'string', 'format': 'color'}).mapErrors({
+        }).errors[0].validatorSubType.should.equal('color');
+      });
+
+    });
+
+    describe('style', function () {
+
+      it('should provide custom error message for property', function () {
+        this.validator.validate("0", {'type': 'string', 'format': 'style'}).mapErrors({
+          'instance': 'Custom error message'
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator type', function () {
+        this.validator.validate("0", {'type': 'string', 'format': 'style'}).mapErrors({
+          'instance': {
+            'format': 'Custom error message'
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator sub-type', function () {
+        this.validator.validate("0", {'type': 'string', 'format': 'style'}).mapErrors({
+          'instance': {
+            'format': {
+              'style': 'Custom error message'
+            }
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide a validator type', function () {
+        this.validator.validate("0", {'type': 'string', 'format': 'style'}).mapErrors({
+        }).errors[0].validatorType.should.equal('format');
+      });
+
+      it('should provide a validator sub-type', function () {
+        this.validator.validate("0", {'type': 'string', 'format': 'style'}).mapErrors({
+        }).errors[0].validatorSubType.should.equal('style');
+      });
+
+    });
+
+    describe('phone', function () {
+
+      it('should provide custom error message for property', function () {
+        this.validator.validate("31 42 123 4567", {'type': 'string', 'format': 'phone'}).mapErrors({
+          'instance': 'Custom error message'
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator type', function () {
+        this.validator.validate("31 42 123 4567", {'type': 'string', 'format': 'phone'}).mapErrors({
+          'instance': {
+            'format': 'Custom error message'
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator sub-type', function () {
+        this.validator.validate("31 42 123 4567", {'type': 'string', 'format': 'phone'}).mapErrors({
+          'instance': {
+            'format': {
+              'phone': 'Custom error message'
+            }
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide a validator type', function () {
+        this.validator.validate("31 42 123 4567", {'type': 'string', 'format': 'phone'}).mapErrors({
+        }).errors[0].validatorType.should.equal('format');
+      });
+
+      it('should provide a validator sub-type', function () {
+        this.validator.validate("31 42 123 4567", {'type': 'string', 'format': 'phone'}).mapErrors({
+        }).errors[0].validatorSubType.should.equal('phone');
+      });
+
+    });
+
+    describe('uri', function () {
+
+      it('should provide custom error message for property', function () {
+        this.validator.validate("tdegrunt", {'type': 'string', 'format': 'uri'}).mapErrors({
+          'instance': 'Custom error message'
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator type', function () {
+        this.validator.validate("tdegrunt", {'type': 'string', 'format': 'uri'}).mapErrors({
+          'instance': {
+            'format': 'Custom error message'
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator sub-type', function () {
+        this.validator.validate("tdegrunt", {'type': 'string', 'format': 'uri'}).mapErrors({
+          'instance': {
+            'format': {
+              'uri': 'Custom error message'
+            }
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide a validator type', function () {
+        this.validator.validate("tdegrunt", {'type': 'string', 'format': 'uri'}).mapErrors({
+        }).errors[0].validatorType.should.equal('format');
+      });
+
+      it('should provide a validator sub-type', function () {
+        this.validator.validate("tdegrunt", {'type': 'string', 'format': 'uri'}).mapErrors({
+        }).errors[0].validatorSubType.should.equal('uri');
+      });
+
+    });
+
+    describe('email', function () {
+
+      it('should provide custom error message for property', function () {
+        this.validator.validate("obama@", {'type': 'string', 'format': 'email'}).mapErrors({
+          'instance': 'Custom error message'
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator type', function () {
+        this.validator.validate("obama@", {'type': 'string', 'format': 'email'}).mapErrors({
+          'instance': {
+            'format': 'Custom error message'
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator sub-type', function () {
+        this.validator.validate("obama@", {'type': 'string', 'format': 'email'}).mapErrors({
+          'instance': {
+            'format': {
+              'email': 'Custom error message'
+            }
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide a validator type', function () {
+        this.validator.validate("obama@", {'type': 'string', 'format': 'email'}).mapErrors({
+        }).errors[0].validatorType.should.equal('format');
+      });
+
+      it('should provide a validator sub-type', function () {
+        this.validator.validate("obama@", {'type': 'string', 'format': 'email'}).mapErrors({
+        }).errors[0].validatorSubType.should.equal('email');
+      });
+
+    });
+
+    describe('ip-address', function () {
+
+      it('should provide custom error message for property', function () {
+        this.validator.validate("192.168.0", {'type': 'string', 'format': 'ip-address'}).mapErrors({
+          'instance': 'Custom error message'
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator type', function () {
+        this.validator.validate("192.168.0", {'type': 'string', 'format': 'ip-address'}).mapErrors({
+          'instance': {
+            'format': 'Custom error message'
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator sub-type', function () {
+        this.validator.validate("192.168.0", {'type': 'string', 'format': 'ip-address'}).mapErrors({
+          'instance': {
+            'format': {
+              'ip-address': 'Custom error message'
+            }
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide a validator type', function () {
+        this.validator.validate("192.168.0", {'type': 'string', 'format': 'ip-address'}).mapErrors({
+        }).errors[0].validatorType.should.equal('format');
+      });
+
+      it('should provide a validator sub-type', function () {
+        this.validator.validate("192.168.0", {'type': 'string', 'format': 'ip-address'}).mapErrors({
+        }).errors[0].validatorSubType.should.equal('ip-address');
+      });
+
+    });
+
+    describe('ipv6', function () {
+
+      it('should provide custom error message for property', function () {
+        this.validator.validate("127.0.0.1", {'type': 'string', 'format': 'ipv6'}).mapErrors({
+          'instance': 'Custom error message'
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator type', function () {
+        this.validator.validate("127.0.0.1", {'type': 'string', 'format': 'ipv6'}).mapErrors({
+          'instance': {
+            'format': 'Custom error message'
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator sub-type', function () {
+        this.validator.validate("127.0.0.1", {'type': 'string', 'format': 'ipv6'}).mapErrors({
+          'instance': {
+            'format': {
+              'ipv6': 'Custom error message'
+            }
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide a validator type', function () {
+        this.validator.validate("127.0.0.1", {'type': 'string', 'format': 'ipv6'}).mapErrors({
+        }).errors[0].validatorType.should.equal('format');
+      });
+
+      it('should provide a validator sub-type', function () {
+        this.validator.validate("127.0.0.1", {'type': 'string', 'format': 'ipv6'}).mapErrors({
+        }).errors[0].validatorSubType.should.equal('ipv6');
+      });
+
+    });
+
+    describe('host-name', function () {
+
+      it('should provide custom error message for property', function () {
+        this.validator.validate("www.-hi-.com", {'type': 'string', 'format': 'host-name'}).mapErrors({
+          'instance': 'Custom error message'
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator type', function () {
+        this.validator.validate("www.-hi-.com", {'type': 'string', 'format': 'host-name'}).mapErrors({
+          'instance': {
+            'format': 'Custom error message'
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator sub-type', function () {
+        this.validator.validate("www.-hi-.com", {'type': 'string', 'format': 'host-name'}).mapErrors({
+          'instance': {
+            'format': {
+              'host-name': 'Custom error message'
+            }
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide a validator type', function () {
+        this.validator.validate("www.-hi-.com", {'type': 'string', 'format': 'host-name'}).mapErrors({
+        }).errors[0].validatorType.should.equal('format');
+      });
+
+      it('should provide a validator sub-type', function () {
+        this.validator.validate("www.-hi-.com", {'type': 'string', 'format': 'host-name'}).mapErrors({
+        }).errors[0].validatorSubType.should.equal('host-name');
+      });
+
+    });
+
+
+    describe('alpha', function () {
+
+      it('should provide custom error message for property', function () {
+        this.validator.validate("www.-hi-.com", {'type': 'string', 'format': 'alpha'}).mapErrors({
+          'instance': 'Custom error message'
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator type', function () {
+        this.validator.validate("www.-hi-.com", {'type': 'string', 'format': 'alpha'}).mapErrors({
+          'instance': {
+            'format': 'Custom error message'
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator sub-type', function () {
+        this.validator.validate("www.-hi-.com", {'type': 'string', 'format': 'alpha'}).mapErrors({
+          'instance': {
+            'format': {
+              'alpha': 'Custom error message'
+            }
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide a validator type', function () {
+        this.validator.validate("www.-hi-.com", {'type': 'string', 'format': 'alpha'}).mapErrors({
+        }).errors[0].validatorType.should.equal('format');
+      });
+
+      it('should provide a validator sub-type', function () {
+        this.validator.validate("www.-hi-.com", {'type': 'string', 'format': 'alpha'}).mapErrors({
+        }).errors[0].validatorSubType.should.equal('alpha');
+      });
+
+    });
+
+    describe('alphanumeric', function () {
+
+      it('should provide custom error message for property', function () {
+        this.validator.validate("1test!", {'type': 'string', 'format': 'alphanumeric'}).mapErrors({
+          'instance': 'Custom error message'
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator type', function () {
+        this.validator.validate("1test!", {'type': 'string', 'format': 'alphanumeric'}).mapErrors({
+          'instance': {
+            'format': 'Custom error message'
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator sub-type', function () {
+        this.validator.validate("1test!", {'type': 'string', 'format': 'alphanumeric'}).mapErrors({
+          'instance': {
+            'format': {
+              'alphanumeric': 'Custom error message'
+            }
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide a validator type', function () {
+        this.validator.validate("1test!", {'type': 'string', 'format': 'alphanumeric'}).mapErrors({
+        }).errors[0].validatorType.should.equal('format');
+      });
+
+      it('should provide a validator sub-type', function () {
+        this.validator.validate("1test!", {'type': 'string', 'format': 'alphanumeric'}).mapErrors({
+        }).errors[0].validatorSubType.should.equal('alphanumeric');
+      });
+
+    });
+  });
+
+  describe('Arrays', function () {
+    beforeEach(function () {
+      this.validator = new Validator();
+    });
+
+    describe('simple array', function () {
+
+      it('should provide custom error message for property', function () {
+        this.validator.validate(0, {'type': 'array'}).mapErrors({
+          'instance': 'Custom error message'
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator type', function () {
+        this.validator.validate(0, {'type': 'array'}).mapErrors({
+          'instance': {
+            'type': 'Custom error message'
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator sub-type', function () {
+        this.validator.validate(0, {'type': 'array'}).mapErrors({
+          'instance': {
+            'type': {
+              'array': 'Custom error message'
+            }
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide a validator type', function () {
+        this.validator.validate(0, {'type': 'array'}).mapErrors({
+        }).errors[0].validatorType.should.equal('type');
+      });
+
+      it('should provide a validator sub-type', function () {
+        this.validator.validate(0, {'type': 'array'}).mapErrors({
+        }).errors[0].validatorSubType.should.equal('array');
+      });
+
+      describe('attribute on array items', function () {
+        it('should provide custom error message for property', function () {
+          this.validator.validate(['1', '2', '3', 4], {'type': 'array', 'items': {'type': 'string'}}).mapErrors({
+            'instance[]': 'Custom error message'
+          }).errors[0].message.should.equal('Custom error message');
+        });
+
+        it('should provide custom error message for validator type', function () {
+          this.validator.validate(['1', '2', '3', 4], {'type': 'array', 'items': {'type': 'string'}}).mapErrors({
+            'instance[]': {
+              'type': 'Custom error message'
+            }
+          }).errors[0].message.should.equal('Custom error message');
+        });
+
+        it('should provide custom error message for validator sub-type', function () {
+          this.validator.validate(['1', '2', '3', 4], {'type': 'array', 'items': {'type': 'string'}}).mapErrors({
+            'instance[]': {
+              'type': {
+                'string': 'Custom error message'
+              }
+            }
+          }).errors[0].message.should.equal('Custom error message');
+        });
+
+        it('should provide a validator type', function () {
+          this.validator.validate(['1', '2', '3', 4], {'type': 'array', 'items': {'type': 'string'}}).mapErrors({
+          }).errors[0].validatorType.should.equal('type');
+        });
+
+        it('should provide a validator sub-type', function () {
+          this.validator.validate(['1', '2', '3', 4], {'type': 'array', 'items': {'type': 'string'}}).mapErrors({
+          }).errors[0].validatorSubType.should.equal('string');
+        });
+
+        it('should provide custom error message for specific array item', function () {
+          var r = this.validator.validate(['1', 2, '3', 4], {'type': 'array', 'items': {'type': 'string'}}).mapErrors({
+            'instance[]': 'Custom error message',
+            'instance[3]': 'Item-specific custom error message'
+          });
+          r.errors[0].message.should.equal('Custom error message');
+          r.errors[1].message.should.equal('Item-specific custom error message');
+        });
+
+      });
+
+    });
+
+    describe('minItems', function () {
+
+      it('should provide custom error message for property', function () {
+        this.validator.validate([1], {'type': 'array', 'items': {'type': 'number'}, 'minItems': 2}).mapErrors({
+          'instance': 'Custom error message'
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator type', function () {
+        this.validator.validate([1], {'type': 'array', 'items': {'type': 'number'}, 'minItems': 2}).mapErrors({
+          'instance': {
+            'minItems': 'Custom error message'
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide a validator type', function () {
+        this.validator.validate([1], {'type': 'array', 'items': {'type': 'number'}, 'minItems': 2}).mapErrors({
+        }).errors[0].validatorType.should.equal('minItems');
+      });
+
+      it('should not provide a validator sub-type', function () {
+        should.not.exist(this.validator.validate([1], {'type': 'array', 'items': {'type': 'number'}, 'minItems': 2}).mapErrors({
+        }).errors[0].validatorSubType);
+      });
+
+    });
+
+    describe('maxItems', function () {
+
+      it('should provide custom error message for property', function () {
+        this.validator.validate([1, 2, 3], {'type': 'array', 'items': {'type': 'number'}, 'maxItems': 2}).mapErrors({
+          'instance': 'Custom error message'
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator type', function () {
+        this.validator.validate([1, 2, 3], {'type': 'array', 'items': {'type': 'number'}, 'maxItems': 2}).mapErrors({
+          'instance': {
+            'maxItems': 'Custom error message'
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide a validator type', function () {
+        this.validator.validate([1, 2, 3], {'type': 'array', 'items': {'type': 'number'}, 'maxItems': 2}).mapErrors({
+        }).errors[0].validatorType.should.equal('maxItems');
+      });
+
+      it('should not provide a validator sub-type', function () {
+        should.not.exist(this.validator.validate([1, 2, 3], {'type': 'array', 'items': {'type': 'number'}, 'maxItems': 2}).mapErrors({
+        }).errors[0].validatorSubType);
+      });
+
+    });
+
+    describe('uniqueItems', function () {
+
+      it('should provide custom error message for property', function () {
+        this.validator.validate([1, 2, 4, 1, 3, 5], {'type': 'array', 'uniqueItems': true}).mapErrors({
+          'instance': 'Custom error message'
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator type', function () {
+        this.validator.validate([1, 2, 4, 1, 3, 5], {'type': 'array', 'uniqueItems': true}).mapErrors({
+          'instance': {
+            'uniqueItems': 'Custom error message'
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide a validator type', function () {
+        this.validator.validate([1, 2, 4, 1, 3, 5], {'type': 'array', 'uniqueItems': true}).mapErrors({
+        }).errors[0].validatorType.should.equal('uniqueItems');
+      });
+
+      it('should not provide a validator sub-type', function () {
+        should.not.exist(this.validator.validate([1, 2, 4, 1, 3, 5], {'type': 'array', 'uniqueItems': true}).mapErrors({
+        }).errors[0].validatorSubType);
+      });
+
+    });
+  });
+
+  describe('Mixed', function () {
+    beforeEach(function () {
+      this.validator = new Validator();
+      this.mixedSchema = {
+        'type': 'object',
+        'properties': {
+          'name': {'type': 'string'},
+          'lines': {
+            'type': 'array',
+            'items': {'type': 'string'}
+          }
+        }
+      };
+    });
+
+    describe('simple object with array with invalid items', function () {
+      it('should provide custom error message for property', function () {
+        this.validator.validate({'name':'test', 'lines': [1]},this.mixedSchema).mapErrors({
+          'instance.lines[]': 'Custom error message'
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator type', function () {
+        this.validator.validate({'name':'test', 'lines': [1]},this.mixedSchema).mapErrors({
+          'instance.lines[]': {
+            'type': 'Custom error message'
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide custom error message for validator sub-type', function () {
+        this.validator.validate({'name':'test', 'lines': [1]},this.mixedSchema).mapErrors({
+          'instance.lines[]': {
+            'type': {
+              'string': 'Custom error message'
+            }
+          }
+        }).errors[0].message.should.equal('Custom error message');
+      });
+
+      it('should provide a validator type', function () {
+        this.validator.validate({'name':'test', 'lines': [1]},this.mixedSchema).mapErrors({
+          'instance.lines[]': {
+            'type': {
+              'string': 'Custom error message'
+            }
+          }
+        }).errors[0].validatorType.should.equal('type');
+      });
+
+      it('should provide a validator sub-type', function () {
+        this.validator.validate({'name':'test', 'lines': [1]},this.mixedSchema).mapErrors({
+          'instance.lines[]': {
+            'type': {
+              'string': 'Custom error message'
+            }
+          }
+        }).errors[0].validatorSubType.should.equal('string');
+      });
+    });
+  });
+
+});


### PR DESCRIPTION
Hi,

I required custom error messages, so I've made some changes to allow this in a way that shouldn't break existing custom validators etc.

All tests are passing and there's an example of how to use i18n/custom error messages with these changes. I believe this may be useful for issue #50 

Note: For custom validators to be used with i18n/custom error messages they are now required to return ValidatorResult objects rather than just a string.

Cheers, Rich