### PR TITLE
IE8 compatibility: using reserved keywords for attrs 

### DIFF
--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -627,15 +627,15 @@ validators.dependencies = function validateDependencies (instance, schema, optio
  * @param schema
  * @return {String|null}
  */
-validators.enum = function validateEnum (instance, schema) {
-  if (!(schema.enum instanceof Array)) {
+validators['enum'] = function validateEnum (instance, schema) {
+  if (!(schema['enum'] instanceof Array)) {
     throw new SchemaError("enum expects an array", schema);
   }
   if (instance === undefined) {
     return null;
   }
-  if (!schema.enum.some(helpers.deepCompareStrict.bind(null, instance))) {
-    return "is not one of enum values: " + schema.enum;
+  if (!schema['enum'].some(helpers.deepCompareStrict.bind(null, instance))) {
+    return "is not one of enum values: " + schema['enum'];
   }
   return null;
 };

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -187,13 +187,13 @@ Validator.prototype.validateSchema = function validateSchema (instance, schema, 
     return schema;
   }
 
-  if (schema.extends) {
-    if (schema.extends instanceof Array) {
-      schema.extends.forEach(function (s) {
+  if (schema['extends']) {
+    if (schema['extends'] instanceof Array) {
+      schema['extends'].forEach(function (s) {
         schema = helpers.deepMerge(schema, resolve(s, ctx));
       });
     } else {
-      schema = helpers.deepMerge(schema, resolve(schema.extends, ctx));
+      schema = helpers.deepMerge(schema, resolve(schema['extends'], ctx));
     }
   }
 
@@ -298,7 +298,7 @@ types.number = function testNumber (instance) {
 types.array = function testArray (instance) {
   return instance instanceof Array;
 };
-types.null = function testNull (instance) {
+types['null'] = function testNull (instance) {
   return instance === null;
 };
 types.date = function testDate (instance) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Tom de Grunt <tom@degrunt.nl>",
   "name": "jsonschema",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "dependencies": {
   },
   "contributors": [


### PR DESCRIPTION
I ran into a problem with jsonschema when using a package that used jsonschema on the client side. Browserify was bundling jsonschema into the client side js file, and when using in ie8, threw errors due to the use of keywords as attribute names (i.e. enum).

I realise this change is for a small subsection of those ppl forced into supporting ie8 - but I've submitted it anyway in the hope that I can delete my fork :)