### PR TITLE
Added validatorType and validatorSubType properties to ValidationError.

### DIFF
--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -43,13 +43,17 @@ validators.type = function validateType (instance, schema, options, ctx) {
   if (instance === undefined) {
     return null;
   }
+  var result = new ValidatorResult(instance, schema, options, ctx);
   var types = (schema.type instanceof Array) ? schema.type : [schema.type];
   if (!types.some(this.testType.bind(this, instance, schema, options, ctx))) {
-    return "is not of a type(s) " + types.map(function (v) {
-      return v.id && ('<' + v.id + '>') || (v+'');
+    result.addError({
+      validatorType: 'type',
+      message: "is not of a type(s) " + types.map(function (v) {
+        return v.id && ('<' + v.id + '>') || (v+'');
+      })
     });
   }
-  return null;
+  return result;
 };
 
 function testSchema(instance, options, ctx, schema){
@@ -69,15 +73,19 @@ validators.anyOf = function validateAnyOf (instance, schema, options, ctx) {
   if (instance === undefined) {
     return null;
   }
+  var result = new ValidatorResult(instance, schema, options, ctx);
   if (!(schema.anyOf instanceof Array)){
     throw new SchemaError("anyOf must be an array");
   }
   if (!schema.anyOf.some(testSchema.bind(this, instance, options, ctx))) {
-    return "is not any of " + schema.anyOf.map(function (v, i) {
-      return (v.id && ('<' + v.id + '>')) || (v.title && JSON.stringify(v.title)) || (v['$ref'] && ('<' + v['$ref'] + '>')) || '[subschema '+i+']';
+    result.addError({
+      validatorType: 'anyOf',
+      message: "is not any of " + schema.anyOf.map(function (v, i) {
+        return (v.id && ('<' + v.id + '>')) || (v.title && JSON.stringify(v.title)) || (v['$ref'] && ('<' + v['$ref'] + '>')) || '[subschema '+i+']';
+      })
     });
   }
-  return null;
+  return result;
 };
 
 /**
@@ -89,7 +97,6 @@ validators.anyOf = function validateAnyOf (instance, schema, options, ctx) {
  * @return {String|null}
  */
 validators.allOf = function validateAllOf (instance, schema, options, ctx) {
-  var result = new ValidatorResult(instance, schema, options, ctx);
   // Ignore undefined instances
   if (instance === undefined) {
     return null;
@@ -97,12 +104,16 @@ validators.allOf = function validateAllOf (instance, schema, options, ctx) {
   if (!(schema.allOf instanceof Array)){
     throw new SchemaError("allOf must be an array");
   }
+  var result = new ValidatorResult(instance, schema, options, ctx);
   var self = this;
   schema.allOf.forEach(function(v, i){
     var valid = self.validateSchema(instance, v, options, ctx);
     if(!valid.valid){
       var msg = (v.id && ('<' + v.id + '>')) || (v.title && JSON.stringify(v.title)) || (v['$ref'] && ('<' + v['$ref'] + '>')) || '[subschema '+i+']';
-      result.addError('does not match allOf schema ' + msg + ' with ' + valid.errors.length + ' error[s]:');
+      result.addError({
+        validatorType: 'allOf',
+        message: 'does not match allOf schema ' + msg + ' with ' + valid.errors.length + ' error[s]:'
+      });
       result.importErrors(valid);
     }
   });
@@ -125,13 +136,17 @@ validators.oneOf = function validateOneOf (instance, schema, options, ctx) {
   if (!(schema.oneOf instanceof Array)){
     throw new SchemaError("oneOf must be an array");
   }
+  var result = new ValidatorResult(instance, schema, options, ctx);
   var count = schema.oneOf.filter(testSchema.bind(this, instance, options, ctx)).length;
   if (count!==1) {
-    return "is not exactly one from " + schema.oneOf.map(function (v, i) {
-      return (v.id && ('<' + v.id + '>')) || (v.title && JSON.stringify(v.title)) || (v['$ref'] && ('<' + v['$ref'] + '>')) || '[subschema '+i+']';
+    result.addError({
+      validatorType: 'oneOf',
+      message: "is not exactly one from " + schema.oneOf.map(function (v, i) {
+        return (v.id && ('<' + v.id + '>')) || (v.title && JSON.stringify(v.title)) || (v['$ref'] && ('<' + v['$ref'] + '>')) || '[subschema '+i+']';
+      })
     });
   }
-  return null;
+  return result;
 };
 
 /**
@@ -167,7 +182,10 @@ function testAdditionalProperty (instance, schema, options, ctx, property, resul
     return;
   }
   if (schema.additionalProperties === false) {
-    result.addError("additionalProperty '"+property+"' exists in instance when not allowed");
+    result.addError({
+      validatorType: 'additionalProperties',
+      message: "additionalProperty '"+property+"' exists in instance when not allowed"
+    });
   } else {
     var additionalProperties = schema.additionalProperties || {};
     var res = this.validateSchema(instance[property], additionalProperties, options, ctx.makeChild(additionalProperties, property));
@@ -238,15 +256,19 @@ validators.additionalProperties = function validateAdditionalProperties (instanc
  * @param schema
  * @return {String|null}
  */
-validators.minProperties = function validateMinProperties (instance, schema) {
+validators.minProperties = function validateMinProperties (instance, schema, options, ctx) {
   if (!instance || typeof instance !== 'object') {
     return null;
   }
+  var result = new ValidatorResult(instance, schema, options, ctx);
   var keys = Object.keys(instance);
   if (!(keys.length >= schema.minProperties)) {
-    return "does not meet minimum property length of " + schema.minProperties;
+    result.addError({
+      validatorType: 'minProperties',
+      message: "does not meet minimum property length of " + schema.minProperties
+    })
   }
-  return null;
+  return result;
 };
 
 /**
@@ -255,15 +277,19 @@ validators.minProperties = function validateMinProperties (instance, schema) {
  * @param schema
  * @return {String|null}
  */
-validators.maxProperties = function validateMaxProperties (instance, schema) {
+validators.maxProperties = function validateMaxProperties (instance, schema, options, ctx) {
   if (!instance || typeof instance !== 'object') {
     return null;
   }
+  var result = new ValidatorResult(instance, schema, options, ctx);
   var keys = Object.keys(instance);
   if (!(keys.length <= schema.maxProperties)) {
-    return "does not meet maximum property length of " + schema.maxProperties;
+    result.addError({
+      validatorType: 'maxProperties',
+      message: "does not meet maximum property length of " + schema.maxProperties
+    });
   }
-  return null;
+  return result;
 };
 
 /**
@@ -289,7 +315,10 @@ validators.items = function validateItems (instance, schema, options, ctx) {
       return true;
     }
     if (items === false) {
-      result.addError("additionalItems not permitted");
+      result.addError({
+        validatorType: 'items',
+        message: "additionalItems not permitted"
+      });
       return false;
     }
     var res = self.validateSchema(value, items, options, ctx.makeChild(items, i));
@@ -306,10 +335,11 @@ validators.items = function validateItems (instance, schema, options, ctx) {
  * @param schema
  * @return {String|null}
  */
-validators.minimum = function validateMinimum (instance, schema) {
+validators.minimum = function validateMinimum (instance, schema, options, ctx) {
   if (typeof instance !== 'number') {
     return null;
   }
+  var result = new ValidatorResult(instance, schema, options, ctx);
   var valid = true;
   if (schema.exclusiveMinimum && schema.exclusiveMinimum === true) {
     valid = instance > schema.minimum;
@@ -317,9 +347,12 @@ validators.minimum = function validateMinimum (instance, schema) {
     valid = instance >= schema.minimum;
   }
   if (!valid) {
-    return "must have a minimum value of " + schema.minimum;
+    result.addError({
+      validatorType: 'minimum',
+      message: "must have a minimum value of " + schema.minimum
+    });
   }
-  return null;
+  return result;
 };
 
 /**
@@ -328,10 +361,11 @@ validators.minimum = function validateMinimum (instance, schema) {
  * @param schema
  * @return {String|null}
  */
-validators.maximum = function validateMaximum (instance, schema) {
+validators.maximum = function validateMaximum (instance, schema, options, ctx) {
   if (typeof instance !== 'number') {
     return null;
   }
+  var result = new ValidatorResult(instance, schema, options, ctx);
   var valid;
   if (schema.exclusiveMaximum && schema.exclusiveMaximum === true) {
     valid = instance < schema.maximum;
@@ -339,9 +373,12 @@ validators.maximum = function validateMaximum (instance, schema) {
     valid = instance <= schema.maximum;
   }
   if (!valid) {
-    return "must have a maximum value of " + schema.maximum;
+    result.addError({
+      validatorType: 'maximum',
+      message: "must have a maximum value of " + schema.maximum
+    });
   }
-  return null;
+  return result;
 };
 
 /**
@@ -352,7 +389,7 @@ validators.maximum = function validateMaximum (instance, schema) {
  * @param schema
  * @return {String|null}
  */
-validators.divisibleBy = function validateDivisibleBy (instance, schema) {
+validators.divisibleBy = function validateDivisibleBy (instance, schema, options, ctx) {
   if (typeof instance !== 'number') {
     return null;
   }
@@ -361,10 +398,14 @@ validators.divisibleBy = function validateDivisibleBy (instance, schema) {
     throw new SchemaError("divisibleBy cannot be zero");
   }
 
+  var result = new ValidatorResult(instance, schema, options, ctx);
   if (instance / schema.divisibleBy % 1) {
-    return "is not " + schema.divisibleBy;
+    result.addError({
+      validatorType: 'divisibleBy',
+      message: "is not " + schema.divisibleBy
+    });
   }
-  return null;
+  return result;
 };
 
 /**
@@ -375,7 +416,7 @@ validators.divisibleBy = function validateDivisibleBy (instance, schema) {
  * @param schema
  * @return {String|null}
  */
-validators.multipleOf = function validateMultipleOf (instance, schema) {
+validators.multipleOf = function validateMultipleOf (instance, schema, options, ctx) {
   if (typeof instance !== 'number') {
     return null;
   }
@@ -384,10 +425,14 @@ validators.multipleOf = function validateMultipleOf (instance, schema) {
     throw new SchemaError("multipleOf cannot be zero");
   }
 
+  var result = new ValidatorResult(instance, schema, options, ctx);
   if (instance / schema.multipleOf % 1) {
-    return "is not " + schema.multipleOf;
+    result.addError({
+      validatorType: 'multipleOf',
+      message: "is not " + schema.multipleOf
+    });
   }
-  return null;
+  return result;
 };
 
 /**
@@ -397,18 +442,25 @@ validators.multipleOf = function validateMultipleOf (instance, schema) {
  * @return {String|null}
  */
 validators.required = function validateRequired (instance, schema, options, ctx) {
+  var result = new ValidatorResult(instance, schema, options, ctx);
   if (instance === undefined && schema.required === true) {
-    return "is required";
-  }else if (instance && typeof instance==='object' && Array.isArray(schema.required)) {
-    var result = new ValidatorResult(instance, schema, options, ctx);
+    result.addError({
+      validatorType: 'required',
+      message: "is required"
+    });
+  } else if (instance && typeof instance==='object' && Array.isArray(schema.required)) {
     schema.required.forEach(function(n){
       if(instance[n]===undefined){
-        result.addError("requires property "+JSON.stringify(n));
+        var requireVal = JSON.stringify(n);
+        result.addError({
+          validatorType: 'required',
+          validatorSubType: requireVal,
+          message: "requires property " + requireVal
+        });
       }
     });
-    return result;
   }
-  return null;
+  return result;
 };
 
 /**
@@ -417,14 +469,18 @@ validators.required = function validateRequired (instance, schema, options, ctx)
  * @param schema
  * @return {String|null}
  */
-validators.pattern = function validatePattern (instance, schema) {
+validators.pattern = function validatePattern (instance, schema, options, ctx) {
   if (typeof instance !== 'string') {
     return null;
   }
+  var result = new ValidatorResult(instance, schema, options, ctx);
   if (!instance.match(schema.pattern)) {
-    return "does not match pattern " + schema.pattern;
+    result.addError({
+      validatorType: 'pattern',
+      message: "does not match pattern " + schema.pattern
+    });
   }
-  return null;
+  return result;
 };
 
 /**
@@ -451,10 +507,15 @@ validators.format = function validateFormat (instance, schema, options, ctx) {
   if (!(typeof instance === 'string')) {
     return null;
   }
+  var result = new ValidatorResult(instance, schema, options, ctx);
   if (!helpers.isFormat(instance, schema.format)) {
-    return "does not conform to the '" + schema.format + "' format";
+    result.addError({
+      validatorType: 'format',
+      validatorSubType: schema.format,
+      message: "does not conform to the '" + schema.format + "' format"
+    });
   }
-  return null;
+  return result;
 };
 
 /**
@@ -463,14 +524,18 @@ validators.format = function validateFormat (instance, schema, options, ctx) {
  * @param schema
  * @return {String|null}
  */
-validators.minLength = function validateMinLength (instance, schema) {
+validators.minLength = function validateMinLength (instance, schema, options, ctx) {
   if (!(typeof instance === 'string')) {
     return null;
   }
+  var result = new ValidatorResult(instance, schema, options, ctx);
   if (!(instance.length >= schema.minLength)) {
-    return "does not meet minimum length of " + schema.minLength;
+    result.addError({
+      validatorType: 'minLength',
+      message: "does not meet minimum length of " + schema.minLength
+    });
   }
-  return null;
+  return result;
 };
 
 /**
@@ -479,14 +544,18 @@ validators.minLength = function validateMinLength (instance, schema) {
  * @param schema
  * @return {String|null}
  */
-validators.maxLength = function validateMaxLength (instance, schema) {
+validators.maxLength = function validateMaxLength (instance, schema, options, ctx) {
   if (!(typeof instance === 'string')) {
     return null;
   }
+  var result = new ValidatorResult(instance, schema, options, ctx);
   if (!(instance.length <= schema.maxLength)) {
-    return "does not meet maximum length of " + schema.maxLength;
+    result.addError({
+      validatorType: 'maxLength',
+      message: "does not meet maximum length of " + schema.maxLength
+    });
   }
-  return null;
+  return result;
 };
 
 /**
@@ -495,14 +564,18 @@ validators.maxLength = function validateMaxLength (instance, schema) {
  * @param schema
  * @return {String|null}
  */
-validators.minItems = function validateMinItems (instance, schema) {
+validators.minItems = function validateMinItems (instance, schema, options, ctx) {
   if (!(instance instanceof Array)) {
     return null;
   }
+  var result = new ValidatorResult(instance, schema, options, ctx);
   if (!(instance.length >= schema.minItems)) {
-    return "does not meet minimum length of " + schema.minItems;
+    result.addError({
+      validatorType: 'minItems',
+      message: "does not meet minimum length of " + schema.minItems
+    });
   }
-  return null;
+  return result;
 };
 
 /**
@@ -511,14 +584,18 @@ validators.minItems = function validateMinItems (instance, schema) {
  * @param schema
  * @return {String|null}
  */
-validators.maxItems = function validateMaxItems (instance, schema) {
+validators.maxItems = function validateMaxItems (instance, schema, options, ctx) {
   if (!(instance instanceof Array)) {
     return null;
   }
+  var result = new ValidatorResult(instance, schema, options, ctx);
   if (!(instance.length <= schema.maxItems)) {
-    return "does not meet maximum length of " + schema.maxItems;
+    result.addError({
+      validatorType: 'maxItems',
+      message: "does not meet maximum length of " + schema.maxItems
+    });
   }
-  return null;
+  return result;
 };
 
 /**
@@ -541,7 +618,10 @@ validators.uniqueItems = function validateUniqueItems (instance, schema, options
     return true;
   }
   if (!instance.every(testArrays)) {
-    result.addError("contains duplicate item");
+    result.addError({
+      validatorType: 'uniqueItems',
+      message: "contains duplicate item"
+    });
   }
   return result;
 };
@@ -569,15 +649,18 @@ function testArrays (v, i, a) {
  * @param instance
  * @return {String|null}
  */
-validators.uniqueItems = function validateUniqueItems (instance) {
+validators.uniqueItems = function validateUniqueItems (instance, schema, options, ctx) {
   if (!(instance instanceof Array)) {
     return null;
   }
-
+  var result = new ValidatorResult(instance, schema, options, ctx);
   if (!instance.every(testArrays)) {
-    return "contains duplicate item";
+    result.addError({
+      validatorType: 'uniqueItems',
+      message: "contains duplicate item"
+    });
   }
-  return null;
+  return result;
 };
 
 /**
@@ -589,10 +672,10 @@ validators.uniqueItems = function validateUniqueItems (instance) {
  * @return {String|null|ValidatorResult}
  */
 validators.dependencies = function validateDependencies (instance, schema, options, ctx) {
-  var result = new ValidatorResult(instance, schema, options, ctx);
   if (!instance || typeof instance != 'object') {
     return null;
   }
+  var result = new ValidatorResult(instance, schema, options, ctx);
   for (var property in schema.dependencies) {
     if (instance[property] === undefined) {
       continue;
@@ -605,14 +688,20 @@ validators.dependencies = function validateDependencies (instance, schema, optio
     if (dep instanceof Array) {
       dep.forEach(function (prop) {
         if (instance[prop] === undefined) {
-          result.addError("property " + prop + " not found, required by " + childContext.propertyPath);
+          result.addError({
+            validatorType: 'dependencies',
+            message: "property " + prop + " not found, required by " + childContext.propertyPath
+          });
         }
       });
     } else {
       var res = this.validateSchema(instance, dep, options, childContext);
       if(result.instance !== res.instance) result.instance = res.instance;
       if (res && res.errors.length) {
-        result.addError("does not meet dependency required by " + childContext.propertyPath);
+        result.addError({
+          validatorType: 'dependencies',
+          message: "does not meet dependency required by " + childContext.propertyPath
+        });
         result.importErrors(res);
       }
     }
@@ -627,17 +716,21 @@ validators.dependencies = function validateDependencies (instance, schema, optio
  * @param schema
  * @return {String|null}
  */
-validators['enum'] = function validateEnum (instance, schema) {
+validators['enum'] = function validateEnum (instance, schema, options, ctx) {
   if (!(schema['enum'] instanceof Array)) {
     throw new SchemaError("enum expects an array", schema);
   }
   if (instance === undefined) {
     return null;
   }
+  var result = new ValidatorResult(instance, schema, options, ctx);
   if (!schema['enum'].some(helpers.deepCompareStrict.bind(null, instance))) {
-    return "is not one of enum values: " + schema['enum'];
+    result.addError({
+      validatorType: 'enum',
+      message: "is not one of enum values: " + schema['enum']
+    });
   }
-  return null;
+  return result;
 };
 
 /**
@@ -658,7 +751,10 @@ validators.not = validators.disallow = function validateNot (instance, schema, o
   notTypes.forEach(function (type) {
     if (self.testType(instance, schema, options, ctx, type)) {
       var schemaId = type && type.id && ('<' + type.id + '>') || type;
-      result.addError("is of prohibited type " + schemaId);
+      result.addError({
+        validatorType: 'not',
+        message: "is of prohibited type " + schemaId
+      });
     }
   });
   return result;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -2,7 +2,7 @@
 
 var uri = require('url');
 
-var ValidationError = exports.ValidationError = function ValidationError (message, instance, schema, propertyPath) {
+var ValidationError = exports.ValidationError = function ValidationError (message, instance, schema, propertyPath, validatorType, validatorSubType) {
   if (propertyPath) {
     this.property = propertyPath;
   }
@@ -19,6 +19,8 @@ var ValidationError = exports.ValidationError = function ValidationError (messag
   if (instance) {
     this.instance = instance;
   }
+  this.validatorType = validatorType;
+  this.validatorSubType = validatorSubType;
   this.stack = this.toString();
 };
 
@@ -34,8 +36,17 @@ var ValidatorResult = exports.ValidatorResult = function ValidatorResult(instanc
   this.throwError = options && options.throwError;
 };
 
-ValidatorResult.prototype.addError = function addError(message) {
-  var err = new ValidationError(message, this.instance, this.schema, this.propertyPath);
+ValidatorResult.prototype.addError = function addError(detail) {
+  var err;
+  if (typeof detail == 'string') {
+    err = new ValidationError(detail, this.instance, this.schema, this.propertyPath);
+  } else {
+    if (!detail) throw new Error('Missing error detail');
+    if (!detail.message) throw new Error('Missing error message');
+    if (!detail.validatorType) throw new Error('Missing validator type');
+    err = new ValidationError(detail.message, this.instance, this.schema, this.propertyPath, detail.validatorType, detail.validatorSubType);
+  }
+
   if (this.throwError) {
     throw err;
   }
@@ -44,12 +55,12 @@ ValidatorResult.prototype.addError = function addError(message) {
 };
 
 ValidatorResult.prototype.importErrors = function importErrors(res) {
-  if (typeof res == 'string') {
+  if (typeof res == 'string' || (res && res.validatorType)) {
     this.addError(res);
   } else if (res && res.errors) {
     var errs = this.errors;
     res.errors.forEach(function (v) {
-      errs.push(v)
+      errs.push(v);
     });
   }
 };
@@ -59,7 +70,7 @@ ValidatorResult.prototype.toString = function toString(res) {
 };
 
 Object.defineProperty(ValidatorResult.prototype, "valid", { get: function() {
-	return !this.errors.length;
+  return !this.errors.length;
 } });
 
 /**

--- a/test/i18n.js
+++ b/test/i18n.js
@@ -1,0 +1,621 @@
+'use strict';
+
+/*jsl predef:define*/
+/*jsl predef:it*/
+
+var Validator = require('../lib/validator');
+var should = require('chai').should();
+
+describe('i18n', function () {
+  beforeEach(function () {
+    this.validator = new Validator();
+  });
+
+  describe('attributes', function () {
+    beforeEach(function () {
+      this.validator = new Validator();
+    });
+
+    describe('type', function () {
+
+      describe('number', function () {
+
+        it('should provide a validator type', function () {
+          this.validator.validate('not-number', {'type': 'number'})
+            .errors[0].validatorType.should.equal('type');
+        });
+
+        it('should not provide a validator sub-type', function () {
+          should.not.exist(this.validator.validate('not-number', {'type': 'number'})
+            .errors[0].validatorSubType);
+        });
+
+      });
+
+      describe('required', function () {
+
+        it('should provide a validator type', function () {
+          this.validator.validate(undefined, {'type': 'number', 'required': true})
+            .errors[0].validatorType.should.equal('required');
+        });
+
+        it('should not provide a validator sub-type', function () {
+          should.not.exist(this.validator.validate(undefined, {'type': 'number', 'required': true})
+            .errors[0].validatorSubType);
+        });
+
+      });
+
+      describe('null', function () {
+
+        it('should provide a validator type', function () {
+          this.validator.validate('0', {'type': 'null'})
+            .errors[0].validatorType.should.equal('type');
+        });
+
+        it('should not provide a validator sub-type', function () {
+          should.not.exist(this.validator.validate('0', {'type': 'null'})
+            .errors[0].validatorSubType);
+        });
+
+      });
+
+      describe('date', function () {
+
+        it('should provide a validator type', function () {
+          this.validator.validate('0', {'type': 'date'})
+            .errors[0].validatorType.should.equal('type');
+        });
+
+        it('should not provide a validator sub-type', function () {
+          should.not.exist(this.validator.validate('0', {'type': 'date'})
+            .errors[0].validatorSubType);
+        });
+
+      });
+
+      describe('integer', function () {
+
+        it('should provide a validator type', function () {
+          this.validator.validate(0.25, {'type': 'integer'})
+            .errors[0].validatorType.should.equal('type');
+        });
+
+        it('should not provide a validator sub-type', function () {
+          should.not.exist(this.validator.validate(0.25, {'type': 'integer'})
+            .errors[0].validatorSubType);
+        });
+
+      });
+
+      describe('boolean', function () {
+
+        it('should provide a validator type', function () {
+          this.validator.validate('true', {'type': 'boolean'})
+            .errors[0].validatorType.should.equal('type');
+        });
+
+        it('should not provide a validator sub-type', function () {
+          should.not.exist(this.validator.validate('true', {'type': 'boolean'})
+            .errors[0].validatorSubType);
+        });
+
+      });
+
+      describe('any', function () {
+
+        //NOTE: Because any will let through everything, the custom message must go on the required attribute
+
+        it('should provide a validator type', function () {
+          this.validator.validate(undefined, {'type': 'any', required: true})
+            .errors[0].validatorType.should.equal('required');
+        });
+
+        it('should not provide a validator sub-type', function () {
+          should.not.exist(this.validator.validate(undefined, {'type': 'any', required: true})
+            .errors[0].validatorSubType);
+        });
+
+      });
+    });
+
+    describe('minimum', function () {
+
+      it('should provide a validator type', function () {
+        this.validator.validate(1, {'type': 'number', 'minimum': 2})
+            .errors[0].validatorType.should.equal('minimum');
+      });
+
+      it('should not provide a validator sub-type', function () {
+        should.not.exist(this.validator.validate(1, {'type': 'number', 'minimum': 2})
+            .errors[0].validatorSubType);
+      });
+
+      describe('exclusiveMinimum', function () {
+
+        it('should provide a validator type', function () {
+          this.validator.validate(1, {'type': 'number', 'minimum': 1, 'exclusiveMinimum': true})
+            .errors[0].validatorType.should.equal('minimum');
+        });
+
+        it('should not provide a validator sub-type', function () {
+          should.not.exist(this.validator.validate(1, {'type': 'number', 'minimum': 1, 'exclusiveMinimum': true})
+            .errors[0].validatorSubType);
+        });
+
+      });
+
+    });
+
+    describe('maximum', function () {
+
+      it('should provide a validator type', function () {
+        this.validator.validate(3, {'type': 'number', 'maximum': 1})
+            .errors[0].validatorType.should.equal('maximum');
+      });
+
+      it('should not provide a validator sub-type', function () {
+        should.not.exist(this.validator.validate(3, {'type': 'number', 'maximum': 1})
+            .errors[0].validatorSubType);
+      });
+
+      describe('exclusiveMaximum', function () {
+
+        it('should provide a validator type', function () {
+          this.validator.validate(2, {'type': 'number', 'maximum': 1, 'exclusiveMaximum': true})
+            .errors[0].validatorType.should.equal('maximum');
+        });
+
+        it('should not provide a validator sub-type', function () {
+          should.not.exist(this.validator.validate(2, {'type': 'number', 'maximum': 1, 'exclusiveMaximum': true})
+            .errors[0].validatorSubType);
+        });
+
+      });
+
+    });
+
+    describe('divisibleBy', function () {
+
+      it('should provide a validator type', function () {
+        this.validator.validate(1, {'type': 'number', 'divisibleBy': 2})
+            .errors[0].validatorType.should.equal('divisibleBy');
+      });
+
+      it('should not provide a validator sub-type', function () {
+        should.not.exist(this.validator.validate(1, {'type': 'number', 'divisibleBy': 2})
+            .errors[0].validatorSubType);
+      });
+
+    });
+
+    describe('pattern', function () {
+
+      it('should provide a validator type', function () {
+        this.validator.validate('abac', {'type': 'string', 'pattern': 'ab+c'})
+            .errors[0].validatorType.should.equal('pattern');
+      });
+
+      it('should not provide a validator sub-type', function () {
+        should.not.exist(this.validator.validate('abac', {'type': 'string', 'pattern': 'ab+c'})
+            .errors[0].validatorSubType);
+      });
+
+    });
+
+    describe('minLength', function () {
+
+      it('should provide a validator type', function () {
+        this.validator.validate('abcde', {'type': 'string', 'minLength': 6})
+            .errors[0].validatorType.should.equal('minLength');
+      });
+
+      it('should not provide a validator sub-type', function () {
+        should.not.exist(this.validator.validate('abcde', {'type': 'string', 'minLength': 6})
+            .errors[0].validatorSubType);
+      });
+
+    });
+
+    describe('maxLength', function () {
+
+      it('should provide a validator type', function () {
+        this.validator.validate('abcde', {'type': 'string', 'maxLength': 4})
+            .errors[0].validatorType.should.equal('maxLength');
+      });
+
+      it('should not provide a validator sub-type', function () {
+        should.not.exist(this.validator.validate('abcde', {'type': 'string', 'maxLength': 4})
+            .errors[0].validatorSubType);
+      });
+
+    });
+
+    describe('enum', function () {
+
+      it('should provide a validator type', function () {
+        this.validator.validate('abcde', {'type': 'string', 'enum': ['abcdf', 'abcdd']})
+            .errors[0].validatorType.should.equal('enum');
+      });
+
+      it('should not provide a validator sub-type', function () {
+        should.not.exist(this.validator.validate('abcde', {'type': 'string', 'enum': ['abcdf', 'abcdd']})
+            .errors[0].validatorSubType);
+      });
+
+    });
+
+    describe('not', function () {
+
+      it('should provide a validator type', function () {
+        this.validator.validate([1], {'type': 'any', 'not':'array'})
+            .errors[0].validatorType.should.equal('not');
+      });
+
+      it('should not provide a validator sub-type', function () {
+        should.not.exist(this.validator.validate([1], {'type': 'any', 'not':'array'})
+            .errors[0].validatorSubType);
+      });
+
+      it('should prohibit specified types', function () {
+        this.validator.validate([1], {'type': 'any', 'not':'array'}).valid.should.be.false;
+      });
+    });
+
+    describe('disallow', function () {
+
+      //NOTE: 'disallow' is a depreciated alias for 'not', custom error message will always use 'not' field
+
+      it('should provide a validator type', function () {
+        this.validator.validate([1], {'type': 'any', 'disallow':'array'})
+            .errors[0].validatorType.should.equal('not');
+      });
+
+      it('should not provide a validator sub-type', function () {
+        should.not.exist(this.validator.validate([1], {'type': 'any', 'disallow':'array'})
+            .errors[0].validatorSubType);
+      });
+
+      it('should prohibit specified types', function () {
+        this.validator.validate([1], {'type': 'any', 'disallow':'array'}).valid.should.be.false;
+      });
+    });
+
+    describe('dependencies', function () {
+
+      it('should provide a validator type', function () {
+        this.validator.validate({quux: 1, foo: 1}, {'dependencies': {'quux': ['foo', 'bar']}})
+            .errors[0].validatorType.should.equal('dependencies');
+      });
+
+      it('should not provide a validator sub-type', function () {
+        should.not.exist(this.validator.validate({quux: 1, foo: 1}, {'dependencies': {'quux': ['foo', 'bar']}})
+            .errors[0].validatorSubType);
+      });
+
+    });
+  });
+
+  describe('Formats', function () {
+    beforeEach(function () {
+      this.validator = new Validator();
+    });
+
+    describe('date-time', function () {
+
+      it('should provide a validator type', function () {
+        this.validator.validate("2012-07-08", {'type': 'string', 'format': 'date-time'})
+            .errors[0].validatorType.should.equal('format');
+      });
+
+      it('should provide a validator sub-type', function () {
+        this.validator.validate("2012-07-08", {'type': 'string', 'format': 'date-time'})
+            .errors[0].validatorSubType.should.equal('date-time');
+      });
+
+    });
+
+    describe('date', function () {
+
+      it('should provide a validator type', function () {
+        this.validator.validate("TEST2012-07-08", {'type': 'string', 'format': 'date'})
+            .errors[0].validatorType.should.equal('format');
+      });
+
+      it('should provide a validator sub-type', function () {
+        this.validator.validate("TEST2012-07-08", {'type': 'string', 'format': 'date'})
+            .errors[0].validatorSubType.should.equal('date');
+      });
+
+    });
+
+    describe('time', function () {
+
+      it('should provide a validator type', function () {
+        this.validator.validate("16:41:41.532Z", {'type': 'string', 'format': 'time'})
+            .errors[0].validatorType.should.equal('format');
+      });
+
+      it('should provide a validator sub-type', function () {
+        this.validator.validate("16:41:41.532Z", {'type': 'string', 'format': 'time'})
+            .errors[0].validatorSubType.should.equal('time');
+      });
+
+    });
+
+    describe('utc-millisec', function () {
+
+      it('should provide a validator type', function () {
+        this.validator.validate("16:41:41.532Z", {'type': 'string', 'format': 'utc-millisec'})
+            .errors[0].validatorType.should.equal('format');
+      });
+
+      it('should provide a validator sub-type', function () {
+        this.validator.validate("16:41:41.532Z", {'type': 'string', 'format': 'utc-millisec'})
+            .errors[0].validatorSubType.should.equal('utc-millisec');
+      });
+
+    });
+
+    describe('regex', function () {
+
+      it('should provide a validator type', function () {
+        this.validator.validate("/^(abc]/", {'type': 'string', 'format': 'regex'})
+            .errors[0].validatorType.should.equal('format');
+      });
+
+      it('should provide a validator sub-type', function () {
+        this.validator.validate("/^(abc]/", {'type': 'string', 'format': 'regex'})
+            .errors[0].validatorSubType.should.equal('regex');
+      });
+
+    });
+
+    describe('color', function () {
+
+      it('should provide a validator type', function () {
+        this.validator.validate("json", {'type': 'string', 'format': 'color'})
+            .errors[0].validatorType.should.equal('format');
+      });
+
+      it('should provide a validator sub-type', function () {
+        this.validator.validate("json", {'type': 'string', 'format': 'color'})
+            .errors[0].validatorSubType.should.equal('color');
+      });
+
+    });
+
+    describe('style', function () {
+
+      it('should provide a validator type', function () {
+        this.validator.validate("0", {'type': 'string', 'format': 'style'})
+            .errors[0].validatorType.should.equal('format');
+      });
+
+      it('should provide a validator sub-type', function () {
+        this.validator.validate("0", {'type': 'string', 'format': 'style'})
+            .errors[0].validatorSubType.should.equal('style');
+      });
+
+    });
+
+    describe('phone', function () {
+
+      it('should provide a validator type', function () {
+        this.validator.validate("31 42 123 4567", {'type': 'string', 'format': 'phone'})
+            .errors[0].validatorType.should.equal('format');
+      });
+
+      it('should provide a validator sub-type', function () {
+        this.validator.validate("31 42 123 4567", {'type': 'string', 'format': 'phone'})
+            .errors[0].validatorSubType.should.equal('phone');
+      });
+
+    });
+
+    describe('uri', function () {
+
+      it('should provide a validator type', function () {
+        this.validator.validate("tdegrunt", {'type': 'string', 'format': 'uri'})
+            .errors[0].validatorType.should.equal('format');
+      });
+
+      it('should provide a validator sub-type', function () {
+        this.validator.validate("tdegrunt", {'type': 'string', 'format': 'uri'})
+            .errors[0].validatorSubType.should.equal('uri');
+      });
+
+    });
+
+    describe('email', function () {
+
+      it('should provide a validator type', function () {
+        this.validator.validate("obama@", {'type': 'string', 'format': 'email'})
+            .errors[0].validatorType.should.equal('format');
+      });
+
+      it('should provide a validator sub-type', function () {
+        this.validator.validate("obama@", {'type': 'string', 'format': 'email'})
+            .errors[0].validatorSubType.should.equal('email');
+      });
+
+    });
+
+    describe('ip-address', function () {
+
+      it('should provide a validator type', function () {
+        this.validator.validate("192.168.0", {'type': 'string', 'format': 'ip-address'})
+            .errors[0].validatorType.should.equal('format');
+      });
+
+      it('should provide a validator sub-type', function () {
+        this.validator.validate("192.168.0", {'type': 'string', 'format': 'ip-address'})
+            .errors[0].validatorSubType.should.equal('ip-address');
+      });
+
+    });
+
+    describe('ipv6', function () {
+
+      it('should provide a validator type', function () {
+        this.validator.validate("127.0.0.1", {'type': 'string', 'format': 'ipv6'})
+            .errors[0].validatorType.should.equal('format');
+      });
+
+      it('should provide a validator sub-type', function () {
+        this.validator.validate("127.0.0.1", {'type': 'string', 'format': 'ipv6'})
+            .errors[0].validatorSubType.should.equal('ipv6');
+      });
+
+    });
+
+    describe('host-name', function () {
+
+      it('should provide a validator type', function () {
+        this.validator.validate("www.-hi-.com", {'type': 'string', 'format': 'host-name'})
+            .errors[0].validatorType.should.equal('format');
+      });
+
+      it('should provide a validator sub-type', function () {
+        this.validator.validate("www.-hi-.com", {'type': 'string', 'format': 'host-name'})
+            .errors[0].validatorSubType.should.equal('host-name');
+      });
+
+    });
+
+
+    describe('alpha', function () {
+
+      it('should provide a validator type', function () {
+        this.validator.validate("www.-hi-.com", {'type': 'string', 'format': 'alpha'})
+            .errors[0].validatorType.should.equal('format');
+      });
+
+      it('should provide a validator sub-type', function () {
+        this.validator.validate("www.-hi-.com", {'type': 'string', 'format': 'alpha'})
+            .errors[0].validatorSubType.should.equal('alpha');
+      });
+
+    });
+
+    describe('alphanumeric', function () {
+
+      it('should provide a validator type', function () {
+        this.validator.validate("1test!", {'type': 'string', 'format': 'alphanumeric'})
+            .errors[0].validatorType.should.equal('format');
+      });
+
+      it('should provide a validator sub-type', function () {
+        this.validator.validate("1test!", {'type': 'string', 'format': 'alphanumeric'})
+            .errors[0].validatorSubType.should.equal('alphanumeric');
+      });
+
+    });
+  });
+
+  describe('Arrays', function () {
+    beforeEach(function () {
+      this.validator = new Validator();
+    });
+
+    describe('simple array', function () {
+
+      it('should provide a validator type', function () {
+        this.validator.validate(0, {'type': 'array'})
+            .errors[0].validatorType.should.equal('type');
+      });
+
+      it('should not provide a validator sub-type', function () {
+        should.not.exist(this.validator.validate(0, {'type': 'array'})
+            .errors[0].validatorSubType);
+      });
+
+      describe('attribute on array items', function () {
+
+        it('should provide a validator type', function () {
+          this.validator.validate(['1', '2', '3', 4], {'type': 'array', 'items': {'type': 'string'}})
+            .errors[0].validatorType.should.equal('type');
+        });
+
+        it('should provide a validator sub-type', function () {
+          this.validator.validate(['1', '2', '3', '4$'], {'type': 'array', 'items': {'type': 'string', 'format': 'alphanumeric'}})
+            .errors[0].validatorSubType.should.equal('alphanumeric');
+        });
+
+      });
+
+    });
+
+    describe('minItems', function () {
+
+      it('should provide a validator type', function () {
+        this.validator.validate([1], {'type': 'array', 'items': {'type': 'number'}, 'minItems': 2})
+            .errors[0].validatorType.should.equal('minItems');
+      });
+
+      it('should not provide a validator sub-type', function () {
+        should.not.exist(this.validator.validate([1], {'type': 'array', 'items': {'type': 'number'}, 'minItems': 2})
+            .errors[0].validatorSubType);
+      });
+
+    });
+
+    describe('maxItems', function () {
+
+      it('should provide a validator type', function () {
+        this.validator.validate([1, 2, 3], {'type': 'array', 'items': {'type': 'number'}, 'maxItems': 2})
+            .errors[0].validatorType.should.equal('maxItems');
+      });
+
+      it('should not provide a validator sub-type', function () {
+        should.not.exist(this.validator.validate([1, 2, 3], {'type': 'array', 'items': {'type': 'number'}, 'maxItems': 2})
+            .errors[0].validatorSubType);
+      });
+
+    });
+
+    describe('uniqueItems', function () {
+
+      it('should provide a validator type', function () {
+        this.validator.validate([1, 2, 4, 1, 3, 5], {'type': 'array', 'uniqueItems': true})
+            .errors[0].validatorType.should.equal('uniqueItems');
+      });
+
+      it('should not provide a validator sub-type', function () {
+        should.not.exist(this.validator.validate([1, 2, 4, 1, 3, 5], {'type': 'array', 'uniqueItems': true})
+            .errors[0].validatorSubType);
+      });
+
+    });
+  });
+
+  describe('Mixed', function () {
+    beforeEach(function () {
+      this.validator = new Validator();
+      this.mixedSchema = {
+        'type': 'object',
+        'properties': {
+          'name': {'type': 'string'},
+          'lines': {
+            'type': 'array',
+            'items': {'type': 'string', 'format': 'alphanumeric'}
+          }
+        }
+      };
+    });
+
+    describe('simple object with array with invalid items', function () {
+
+      it('should provide a validator type', function () {
+        this.validator.validate({'name':'test', 'lines': ['1$']},this.mixedSchema)
+          .errors[0].validatorType.should.equal('format');
+      });
+
+      it('should provide a validator sub-type', function () {
+        this.validator.validate({'name':'test', 'lines': ['1$']},this.mixedSchema)
+          .errors[0].validatorSubType.should.equal('alphanumeric');
+      });
+    });
+  });
+
+});


### PR DESCRIPTION
As per our discussion in #108 here's the reworked pull request without the mapErrors and associated code.

To summarise:
* Properties ```validatorType``` and ```validatorSubType``` added to validation errors. 
* The built-in validators have been updated to make use of the ```validatorType/SubType``` properties.
* Any existing custom validators that return a string instead of a ValidatorResult will still work, but the ```validatorType``` and ```validatorSubType``` will be undefined for these.

I haven't had time yet to put in the 'args' property that we discussed, will open another pull request when I can.

Cheers, Rich