### PR TITLE
BugFixes: (instanceof Array/Object/RegExp) and (undefined property handling)

### DIFF
--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -168,12 +168,12 @@ validators.properties = function validateProperties (instance, schema, options, 
   if(instance === undefined || !helpers.isObject(instance)) return;
   var result = new ValidatorResult(instance, schema, options, ctx);
   var properties = schema.properties || {};
-  for (var property in properties) {
+  Object.keys(properties).forEach(function(property) {
     var prop = (instance || undefined) && instance[property];
     var res = this.validateSchema(prop, properties[property], options, ctx.makeChild(properties[property], property));
     if(res.instance !== result.instance[property]) result.instance[property] = res.instance;
     result.importErrors(res);
-  }
+  }, this);
   return result;
 };
 
@@ -185,7 +185,7 @@ validators.properties = function validateProperties (instance, schema, options, 
  * @return {boolean}
  */
 function testAdditionalProperty (instance, schema, options, ctx, property, result) {
-  if (schema.properties && schema.properties[property] !== undefined) {
+  if (('undefined' === typeof instance[property]) || (schema.properties && schema.properties[property] !== undefined)) {
     return;
   }
   if (schema.additionalProperties === false) {

--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -44,7 +44,7 @@ validators.type = function validateType (instance, schema, options, ctx) {
     return null;
   }
   var result = new ValidatorResult(instance, schema, options, ctx);
-  var types = (schema.type instanceof Array) ? schema.type : [schema.type];
+  var types = helpers.isArray(schema.type) ? schema.type : [schema.type];
   if (!types.some(this.testType.bind(this, instance, schema, options, ctx))) {
     var list = types.map(function (v) {
       return v.id && ('<' + v.id + '>') || (v+'');
@@ -76,7 +76,7 @@ validators.anyOf = function validateAnyOf (instance, schema, options, ctx) {
     return null;
   }
   var result = new ValidatorResult(instance, schema, options, ctx);
-  if (!(schema.anyOf instanceof Array)){
+  if (!helpers.isArray(schema.anyOf)){
     throw new SchemaError("anyOf must be an array");
   }
   if (!schema.anyOf.some(testSchema.bind(this, instance, options, ctx))) {
@@ -105,7 +105,7 @@ validators.allOf = function validateAllOf (instance, schema, options, ctx) {
   if (instance === undefined) {
     return null;
   }
-  if (!(schema.allOf instanceof Array)){
+  if (!helpers.isArray(schema.allOf)){
     throw new SchemaError("allOf must be an array");
   }
   var result = new ValidatorResult(instance, schema, options, ctx);
@@ -138,7 +138,7 @@ validators.oneOf = function validateOneOf (instance, schema, options, ctx) {
   if (instance === undefined) {
     return null;
   }
-  if (!(schema.oneOf instanceof Array)){
+  if (!helpers.isArray(schema.oneOf)){
     throw new SchemaError("oneOf must be an array");
   }
   var result = new ValidatorResult(instance, schema, options, ctx);
@@ -165,7 +165,7 @@ validators.oneOf = function validateOneOf (instance, schema, options, ctx) {
  * @return {String|null|ValidatorResult}
  */
 validators.properties = function validateProperties (instance, schema, options, ctx) {
-  if(instance === undefined || !(instance instanceof Object)) return;
+  if(instance === undefined || !helpers.isObject(instance)) return;
   var result = new ValidatorResult(instance, schema, options, ctx);
   var properties = schema.properties || {};
   for (var property in properties) {
@@ -311,7 +311,7 @@ validators.maxProperties = function validateMaxProperties (instance, schema, opt
  * @return {String|null|ValidatorResult}
  */
 validators.items = function validateItems (instance, schema, options, ctx) {
-  if (!(instance instanceof Array)) {
+  if (!helpers.isArray(instance)) {
     return null;
   }
   var self = this;
@@ -320,7 +320,7 @@ validators.items = function validateItems (instance, schema, options, ctx) {
     return result;
   }
   instance.every(function (value, i) {
-    var items = (schema.items instanceof Array) ? (schema.items[i] || schema.additionalItems) : schema.items;
+    var items = helpers.isArray(schema.items) ? (schema.items[i] || schema.additionalItems) : schema.items;
     if (items === undefined) {
       return true;
     }
@@ -462,7 +462,7 @@ validators.required = function validateRequired (instance, schema, options, ctx)
       name: 'required',
       message: "is required"
     });
-  } else if (instance && typeof instance==='object' && Array.isArray(schema.required)) {
+  } else if (instance && typeof instance==='object' && helpers.isArray(schema.required)) {
     schema.required.forEach(function(n){
       if(instance[n]===undefined){
         result.addError({
@@ -581,7 +581,7 @@ validators.maxLength = function validateMaxLength (instance, schema, options, ct
  * @return {String|null}
  */
 validators.minItems = function validateMinItems (instance, schema, options, ctx) {
-  if (!(instance instanceof Array)) {
+  if (!helpers.isArray(instance)) {
     return null;
   }
   var result = new ValidatorResult(instance, schema, options, ctx);
@@ -602,7 +602,7 @@ validators.minItems = function validateMinItems (instance, schema, options, ctx)
  * @return {String|null}
  */
 validators.maxItems = function validateMaxItems (instance, schema, options, ctx) {
-  if (!(instance instanceof Array)) {
+  if (!helpers.isArray(instance)) {
     return null;
   }
   var result = new ValidatorResult(instance, schema, options, ctx);
@@ -626,7 +626,7 @@ validators.maxItems = function validateMaxItems (instance, schema, options, ctx)
  */
 validators.uniqueItems = function validateUniqueItems (instance, schema, options, ctx) {
   var result = new ValidatorResult(instance, schema, options, ctx);
-  if (!(instance instanceof Array)) {
+  if (!helpers.isArray(instance)) {
     return result;
   }
   function testArrays (v, i, a) {
@@ -668,7 +668,7 @@ function testArrays (v, i, a) {
  * @return {String|null}
  */
 validators.uniqueItems = function validateUniqueItems (instance, schema, options, ctx) {
-  if (!(instance instanceof Array)) {
+  if (!helpers.isArray(instance)) {
     return null;
   }
   var result = new ValidatorResult(instance, schema, options, ctx);
@@ -703,7 +703,7 @@ validators.dependencies = function validateDependencies (instance, schema, optio
     if (typeof dep == 'string') {
       dep = [dep];
     }
-    if (dep instanceof Array) {
+    if (helpers.isArray(dep)) {
       dep.forEach(function (prop) {
         if (instance[prop] === undefined) {
           result.addError({
@@ -739,7 +739,7 @@ validators.dependencies = function validateDependencies (instance, schema, optio
  * @return {ValidatorResult|null}
  */
 validators['enum'] = function validateEnum (instance, schema, options, ctx) {
-  if (!(schema['enum'] instanceof Array)) {
+  if (!helpers.isArray(schema['enum'])) {
     throw new SchemaError("enum expects an array", schema);
   }
   if (instance === undefined) {
@@ -770,7 +770,7 @@ validators.not = validators.disallow = function validateNot (instance, schema, o
   var result = new ValidatorResult(instance, schema, options, ctx);
   var notTypes = schema.not || schema.disallow;
   if(!notTypes) return null;
-  if(!(notTypes instanceof Array)) notTypes=[notTypes];
+  if(!helpers.isArray(notTypes)) notTypes=[notTypes];
   notTypes.forEach(function (type) {
     if (self.testType(instance, schema, options, ctx, type)) {
       var schemaId = type && type.id && ('<' + type.id + '>') || type;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var uri = require('url');
+var helpers = exports;
 
 var ValidationError = exports.ValidationError = function ValidationError (message, instance, schema, propertyPath, name, argument) {
   if (propertyPath) {
@@ -151,7 +152,7 @@ FORMAT_REGEXPS.ipv4 = FORMAT_REGEXPS['ip-address'];
 
 exports.isFormat = function isFormat (input, format) {
   if (FORMAT_REGEXPS[format] !== undefined) {
-    if (FORMAT_REGEXPS[format] instanceof RegExp) {
+    if (helpers.isRegExp(FORMAT_REGEXPS[format])) {
       return FORMAT_REGEXPS[format].test(input);
     }
     if (typeof FORMAT_REGEXPS[format] === 'function') {
@@ -159,6 +160,18 @@ exports.isFormat = function isFormat (input, format) {
     }
   }
   return false;
+};
+exports.isRegExp = function isRegExp(val) {
+  return (val && ('object' === typeof val) && (Object.prototype.toString.apply(val) === '[object RegExp]'));
+};
+exports.isArray = function isArray(val) {
+  return ('function' === typeof Array.isArray)?Array.isArray(val):(val && ('object' === typeof val) && (Object.prototype.toString.apply(val) === '[object Array]'));
+};
+exports.isObject = function isObject(val) {
+  return (val && ('object' === typeof val) && (Object.prototype.toString.apply(val) === '[object Object]'));
+};
+exports.isDate = function isDate(val) {
+  return (val && ('object' === typeof val) && (Object.prototype.toString.apply(val) === '[object Date]'));
 };
 
 var makeSuffix = exports.makeSuffix = function makeSuffix (key) {
@@ -179,8 +192,8 @@ exports.deepCompareStrict = function deepCompareStrict (a, b) {
   if (typeof a !== typeof b) {
     return false;
   }
-  if (a instanceof Array) {
-    if (!(b instanceof Array)) {
+  if (helpers.isArray(a)) {
+    if (!helpers.isArray(b)) {
       return false;
     }
     if (a.length !== b.length) {

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -71,8 +71,8 @@ Validator.prototype.addSubSchema = function addSubSchema(baseuri, schema) {
     var documentUri = ourUri.replace(/^([^#]*)#$/, '$1');
     this.schemas[documentUri] = schema;
   }
-  this.addSubSchemaArray(ourBase, ((schema.items instanceof Array)?schema.items:[schema.items]));
-  this.addSubSchemaArray(ourBase, ((schema.extends instanceof Array)?schema.extends:[schema.extends]));
+  this.addSubSchemaArray(ourBase, (helpers.isArray(schema.items)?schema.items:[schema.items]));
+  this.addSubSchemaArray(ourBase, (helpers.isArray(schema.extends)?schema.extends:[schema.extends]));
   this.addSubSchema(ourBase, schema.additionalItems);
   this.addSubSchemaObject(ourBase, schema.properties);
   this.addSubSchema(ourBase, schema.additionalProperties);
@@ -88,7 +88,7 @@ Validator.prototype.addSubSchema = function addSubSchema(baseuri, schema) {
 };
 
 Validator.prototype.addSubSchemaArray = function addSubSchemaArray(baseuri, schemas) {
-  if(!(schemas instanceof Array)) return;
+  if(!helpers.isArray(schemas)) return;
   for(var i=0; i<schemas.length; i++){
     this.addSubSchema(baseuri, schemas[i]);
   }
@@ -189,7 +189,7 @@ Validator.prototype.validateSchema = function validateSchema (instance, schema, 
   }
 
   if (schema['extends']) {
-    if (schema['extends'] instanceof Array) {
+    if (helpers.isArray(schema['extends'])) {
       schema['extends'].forEach(function (s) {
         schema = helpers.deepMerge(schema, resolve(s, ctx));
       });
@@ -297,20 +297,19 @@ types.number = function testNumber (instance) {
   return typeof instance == 'number';
 };
 types.array = function testArray (instance) {
-  return instance instanceof Array;
+  return helpers.isArray(instance);
 };
 types['null'] = function testNull (instance) {
   return instance === null;
 };
 types.date = function testDate (instance) {
-  return instance instanceof Date;
+  return helpers.isDate(instance);
 };
 types.any = function testAny (instance) {
   return true;
 };
 types.object = function testObject (instance) {
-  // TODO: fix this - see #15
-  return instance && (typeof instance) === 'object' && !(instance instanceof Array) && !(instance instanceof Date);
+  return helpers.isObject(instance);
 };
 
 module.exports = Validator;

--- a/test/cross-context.js
+++ b/test/cross-context.js
@@ -1,0 +1,34 @@
+'use strict';
+
+/*jsl predef:define*/
+/*jsl predef:it*/
+
+var Validator = require('../lib/validator');
+var should = require('chai').should();
+
+describe('Cross-Context', function () {
+  describe('cross-context schema', function () {
+    beforeEach(function () {
+      this.validator = new Validator();
+    });
+    it('local-oneOf-schema should validate a simple-value', function () {
+      this.validator.validate(true, localSchema());
+    });
+    it('context-oneOf-schema should validate a simple-value', function() {
+      this.validator.validate(true, contextSchema());
+    });
+  });
+});
+
+function localSchema() {
+    return {
+        oneOf: [
+            { type:'string' },
+            { type: 'boolean' }
+        ]
+    };
+}
+function contextSchema() {
+    var vm = require('vm');
+    return vm.runInNewContext([ '(', ')'].join(JSON.stringify(localSchema())));
+}


### PR DESCRIPTION
Hi,

These are 2 Bug-Fix Commits:

The first eliminated the use of the instanceof operator. This is due to the fact that when the origin of your JSON-Object is from another frame/window in a browser, or another execution-context in node, that operator breaks.

The second makes sure that properties whose value is undefined are handled properly. Since JSON does not have an undefined value, they should be treated as not present.
