### PR TITLE
Adding the ability to add custom formats for all data types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,37 @@ All schema definitions are supported, $schema is ignored.
 ### Types
 All types are supported
 
-### String Formats
+### Formats
+#### Disabling the format keyword.
+
+You may disable format validation by providing `disableFormat: true` to the validator
+options.
+
+#### String Formats
 All formats are supported, phone numbers are expected to follow the [E.123](http://en.wikipedia.org/wiki/E.123) standard.
+
+#### Custom Formats
+You may add your own custom format functions.  Format functions accept the input
+being validated and return a boolean value.  If the returned value is `true`, then
+validation succeeds.  If the returned value is `false`, then validation fails.
+
+* Formats added to `Validator.prototype.customFormats` do not affect previously instantiated
+Validators.  This is to prevent validator instances from being altered once created.
+It is conceivable that multiple validators may be created to handle multiple schemas
+with different formats in a program.
+* Formats added to `validator.customFormats` affect only that Validator instance.
+
+Here is an example that uses custom formats:
+
+```
+Validator.prototype.customFormats.myFormat = function(input) {
+  return input === 'myFormat';
+};
+
+var validator = new Validator();
+validator.validate('myFormat', {type: 'string', format: 'myFormat'}).valid; // true
+validator.validate('foo', {type: 'string', format: 'myFormat'}).valid; // false
+```
 
 ### Results
 The first error found will be thrown as an `Error` object if `options.throwError` is `true`.  Otherwise all results will be appended to the `result.errors` array which also contains the success flag `result.valid`.

--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -498,8 +498,9 @@ validators.pattern = function validatePattern (instance, schema, options, ctx) {
 };
 
 /**
- * Validates whether the instance value is of a certain defined format, when the instance value is a string.
- * The following format are supported:
+ * Validates whether the instance value is of a certain defined format or a custom
+ * format.
+ * The following formats are supported for string types:
  *   - date-time
  *   - date
  *   - time
@@ -518,11 +519,8 @@ validators.pattern = function validatePattern (instance, schema, options, ctx) {
  * @return {String|null}
  */
 validators.format = function validateFormat (instance, schema, options, ctx) {
-  if (!(typeof instance === 'string')) {
-    return null;
-  }
   var result = new ValidatorResult(instance, schema, options, ctx);
-  if (!helpers.isFormat(instance, schema.format)) {
+  if (!result.disableFormat && !helpers.isFormat(instance, schema.format, this)) {
     result.addError({
       name: 'format',
       argument: schema.format,

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -34,6 +34,7 @@ var ValidatorResult = exports.ValidatorResult = function ValidatorResult(instanc
   this.propertyPath = ctx.propertyPath;
   this.errors = [];
   this.throwError = options && options.throwError;
+  this.disableFormat = options && options.disableFormat === true;
 };
 
 ValidatorResult.prototype.addError = function addError(detail) {
@@ -149,14 +150,17 @@ FORMAT_REGEXPS.regexp = FORMAT_REGEXPS.regex;
 FORMAT_REGEXPS.pattern = FORMAT_REGEXPS.regex;
 FORMAT_REGEXPS.ipv4 = FORMAT_REGEXPS['ip-address'];
 
-exports.isFormat = function isFormat (input, format) {
-  if (FORMAT_REGEXPS[format] !== undefined) {
+exports.isFormat = function isFormat (input, format, validator) {
+  if (typeof input === 'string' && FORMAT_REGEXPS[format] !== undefined) {
     if (FORMAT_REGEXPS[format] instanceof RegExp) {
       return FORMAT_REGEXPS[format].test(input);
     }
     if (typeof FORMAT_REGEXPS[format] === 'function') {
       return FORMAT_REGEXPS[format](input);
     }
+  } else if (validator && validator.customFormats &&
+      typeof validator.customFormats[format] === 'function') {
+    return validator.customFormats[format](input);
   }
   return true;
 };

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -14,6 +14,9 @@ var SchemaContext = helpers.SchemaContext;
  * @constructor
  */
 var Validator = function Validator () {
+  // Allow a validator instance to override global custom formats or to have their
+  // own custom formats.
+  this.customFormats = Object.create(Validator.prototype.customFormats);
   this.schemas = {};
   this.unresolvedRefs = [];
 
@@ -21,6 +24,9 @@ var Validator = function Validator () {
   this.types = Object.create(types);
   this.attributes = Object.create(attribute.validators);
 };
+
+// Allow formats to be registered globally.
+Validator.prototype.customFormats = {};
 
 // Hint at the presence of a property
 Validator.prototype.schemas = null;

--- a/test/formats.js
+++ b/test/formats.js
@@ -262,6 +262,75 @@ describe('Formats', function () {
     });
   });
 
+  describe('custom formats', function() {
+    beforeEach(function() {
+      this.validator.customFormats.foo = function(input) {
+        if (input === 'foo') {
+          return true;
+        }
+        return false;
+      };
+
+      this.validator.customFormats.float = function(input) {
+        console.log(input);
+        return /^\d+(?:\.\d+)?$/.test(input);
+      };
+    });
+
+    it('should validate input', function() {
+      this.validator.validate("foo", {'type': 'string', 'format': 'foo'}).valid.should.be.true;
+    });
+
+    it('should validate numeric input', function() {
+      this.validator.validate(32.45, {'type': 'number', 'format': 'float'}).valid.should.be.true;
+    });
+
+    it('should fail input that fails validation', function() {
+      this.validator.validate("boo", {'type': 'string', 'format': 'foo'}).valid.should.be.false;
+    });
+
+    it('should fail numeric input that fails validation', function() {
+      this.validator.validate(NaN, {'type': 'number', 'format': 'float'}).valid.should.be.false;
+    });
+
+    describe('assigned to validator instances', function() {
+      var format;
+
+      beforeEach(function() {
+        format = function() {};
+        this.validator.customFormats.boo = format;
+      });
+
+      it('should not be assigned to the Validator prototype', function() {
+        (typeof Validator.prototype.customFormats.boo).should.equal('undefined');
+      });
+    });
+
+    describe('assigned to the Validator.prototype before validator instances are created', function() {
+      var format;
+
+      beforeEach(function() {
+        format = function() {};
+        Validator.prototype.customFormats.boo = format;
+      });
+
+      afterEach(function() {
+        delete Validator.prototype.customFormats.boo;
+      });
+
+      it('should be assigned to the instances', function() {
+        ((new Validator()).customFormats.boo).should.be.a.function;
+      });
+    });
+  });
+
+  describe('with options.disableFormat === true', function() {
+    it('should validate invalid formats', function() {
+      this.validator.validate("2012-07-08", {'type': 'string', 'format': 'date-time'},
+          {disableFormat: true}).valid.should.be.true;
+    });
+  });
+
   describe('invalid format', function() {
     it('should validate', function () {
       this.validator.validate("url", {'type': 'string', 'format': 'url'}).valid.should.be.true;


### PR DESCRIPTION
* closes #87, closes #118, closes #159, closes #88, closes #140.
* The spec doesn't state that format validation is limited to string types, so removing that restriction with this change.
* Also supporting `options.disableFormat: true` to disable format processing.  The spec states that implementations SHOULD offer an option to disable validation for this keyword.