### PR TITLE
Avoiding closure leaks

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -59,15 +59,15 @@ ValidatorResult.prototype.importErrors = function importErrors(res) {
   if (typeof res == 'string' || (res && res.validatorType)) {
     this.addError(res);
   } else if (res && res.errors) {
-    var errs = this.errors;
-    res.errors.forEach(function (v) {
-      errs.push(v);
-    });
+    Array.prototype.push.apply(this.errors, res.errors);
   }
 };
 
+function stringizer (v,i){
+  return i+': '+v.toString()+'\n';
+}
 ValidatorResult.prototype.toString = function toString(res) {
-  return this.errors.map(function(v,i){ return i+': '+v.toString()+'\n'; }).join('');
+  return this.errors.map(stringizer).join('');
 };
 
 Object.defineProperty(ValidatorResult.prototype, "valid", { get: function() {
@@ -210,44 +210,52 @@ exports.deepCompareStrict = function deepCompareStrict (a, b) {
   return a === b;
 };
 
-module.exports.deepMerge = function deepMerge (target, src) {
+function deepMerger (target, dst, e, i) {
+  if (typeof e === 'object') {
+    dst[i] = deepMerge(target[i], e)
+  } else {
+    if (target.indexOf(e) === -1) {
+      dst.push(e)
+    }
+  }
+}
+
+function copyist (src, dst, key) {
+  dst[key] = src[key];
+}
+
+function copyistWithDeepMerge (target, src, dst, key) {
+  if (typeof src[key] !== 'object' || !src[key]) {
+    dst[key] = src[key];
+  }
+  else {
+    if (!target[key]) {
+      dst[key] = src[key];
+    } else {
+      dst[key] = deepMerge(target[key], src[key])
+    }
+  }
+}
+
+function deepMerge (target, src) {
   var array = Array.isArray(src);
   var dst = array && [] || {};
 
   if (array) {
     target = target || [];
     dst = dst.concat(target);
-    src.forEach(function (e, i) {
-      if (typeof e === 'object') {
-        dst[i] = deepMerge(target[i], e)
-      } else {
-        if (target.indexOf(e) === -1) {
-          dst.push(e)
-        }
-      }
-    });
+    src.forEach(deepMerger.bind(null, target, dst));
   } else {
     if (target && typeof target === 'object') {
-      Object.keys(target).forEach(function (key) {
-        dst[key] = target[key];
-      });
+      Object.keys(target).forEach(copyist.bind(null, target, dst));
     }
-    Object.keys(src).forEach(function (key) {
-      if (typeof src[key] !== 'object' || !src[key]) {
-        dst[key] = src[key];
-      }
-      else {
-        if (!target[key]) {
-          dst[key] = src[key];
-        } else {
-          dst[key] = deepMerge(target[key], src[key])
-        }
-      }
-    });
+    Object.keys(src).forEach(copyistWithDeepMerge.bind(null, target, src, dst));
   }
 
   return dst;
 };
+
+module.exports.deepMerge = deepMerge;
 
 /**
  * Validates instance against the provided schema
@@ -267,6 +275,9 @@ exports.objectGetPath = function objectGetPath(o, s) {
   return o;
 };
 
+function pathEncoder (v) {
+  return '/'+encodeURIComponent(v).replace(/~/g,'%7E');
+}
 /**
  * Accept an Array of property names and return a JSON Pointer URI fragment
  * @param Array a
@@ -275,5 +286,5 @@ exports.objectGetPath = function objectGetPath(o, s) {
 exports.encodePath = function encodePointer(a){
 	// ~ must be encoded explicitly because hacks
 	// the slash is encoded by encodeURIComponent
-	return a.map(function(v){ return '/'+encodeURIComponent(v).replace(/~/g,'%7E'); }).join('');
+	return a.map(pathEncoder).join('');
 };

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -157,6 +157,16 @@ Validator.prototype.validate = function validate (instance, schema, options, ctx
 };
 
 /**
+* @param Object schema
+* @return mixed schema uri or false
+*/
+function shouldResolve(schema) {
+  var ref = (typeof schema === 'string') ? schema : schema.$ref;
+  if (typeof ref=='string') return ref;
+  return false;
+}
+
+/**
  * Validates an instance against the schema (the actual work horse)
  * @param instance
  * @param schema
@@ -166,41 +176,21 @@ Validator.prototype.validate = function validate (instance, schema, options, ctx
  * @return {ValidatorResult}
  */
 Validator.prototype.validateSchema = function validateSchema (instance, schema, options, ctx) {
-  var self = this;
   var result = new ValidatorResult(instance, schema, options, ctx);
   if (!schema) {
     throw new Error("schema is undefined");
   }
 
-  /**
-  * @param Object schema
-  * @return mixed schema uri or false
-  */
-  function shouldResolve(schema) {
-    var ref = (typeof schema === 'string') ? schema : schema.$ref;
-    if (typeof ref=='string') return ref;
-    return false;
-  }
-  /**
-  * @param Object schema
-  * @param SchemaContext ctx
-  * @returns Object schema or resolved schema
-  */
-  function resolve(schema, ctx) {
-    var ref;
-    if(ref = shouldResolve(schema)) {
-      return self.resolve(schema, ref, ctx).subschema;
-    }
-    return schema;
-  }
-
   if (schema['extends']) {
     if (schema['extends'] instanceof Array) {
-      schema['extends'].forEach(function (s) {
-        schema = helpers.deepMerge(schema, resolve(s, ctx));
-      });
+      var schemaobj = {schema: schema, ctx: ctx};
+      schema['extends'].forEach(this.schemaTraverser.bind(this, schemaobj));
+      schema = schemaobj.schema;
+      schemaobj.schema = null;
+      schemaobj.ctx = null;
+      schemaobj = null;
     } else {
-      schema = helpers.deepMerge(schema, resolve(schema['extends'], ctx));
+      schema = helpers.deepMerge(schema, this.superResolve(schema['extends'], ctx));
     }
   }
 
@@ -216,9 +206,9 @@ Validator.prototype.validateSchema = function validateSchema (instance, schema, 
   for (var key in schema) {
     if (!attribute.ignoreProperties[key] && skipAttributes.indexOf(key) < 0) {
       var validatorErr = null;
-      var validator = self.attributes[key];
+      var validator = this.attributes[key];
       if (validator) {
-        validatorErr = validator.call(self, instance, schema, options, ctx);
+        validatorErr = validator.call(this, instance, schema, options, ctx);
       } else if (options.allowUnknownAttributes === false) {
         // This represents an error with the schema itself, not an invalid instance
         throw new SchemaError("Unsupported attribute: " + key, schema);
@@ -235,6 +225,30 @@ Validator.prototype.validateSchema = function validateSchema (instance, schema, 
   }
   return result;
 };
+
+/**
+* @private
+* @param Object schema
+* @param SchemaContext ctx
+* @returns Object schema or resolved schema
+*/
+Validator.prototype.schemaTraverser = function schemaTraverser (schemaobj, s) {
+  schemaobj.schema = helpers.deepMerge(schemaobj.schema, this.superResolve(s, schemaobj.ctx));
+}
+
+/**
+* @private
+* @param Object schema
+* @param SchemaContext ctx
+* @returns Object schema or resolved schema
+*/
+Validator.prototype.superResolve = function superResolve (schema, ctx) {
+  var ref;
+  if(ref = shouldResolve(schema)) {
+    return this.resolve(schema, ref, ctx).subschema;
+  }
+  return schema;
+}
 
 /**
 * @private


### PR DESCRIPTION
The proposed PR gets rid of memory leaks that are introduced via "closure leaks".
The main problem was within the `validateSchema` method of the `Validator` class.
Three closures were produced there: `shouldResolve`, `resolve`, and an `<anonymous>` one.
These three were mutually dependent. However, `shouldResolve` depends on no outer params, so it was taken out of the `validateSchema` and promoted to a standalone function.
`resolve` became the `superResolve` method, and the `<anonymous>` one became the `schemaTraverser` method of the `Validator` class.

In the same manner, the code in `helpers.js` was cleared. Affected are:

- `deepMerge`
- `importErrors` method of the `ValidatorResult` class
- `toString` method of the `ValidatorResult` class
- `encodePath` method of the `ValidatorResult` class