### PR TITLE
Save and return nested errors that cause failure of oneOf and anyOf

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ validator.validate('foo', {type: 'string', format: 'myFormat'}).valid; // false
 ### Results
 The first error found will be thrown as an `Error` object if `options.throwError` is `true`.  Otherwise all results will be appended to the `result.errors` array which also contains the success flag `result.valid`.
 
+When `oneOf` or `anyOf` validations fail, errors that caused any of the sub-schemas referenced therein to fail are not reported, unless `options.nestedErrors` is truthy. This option may be useful when troubleshooting validation errors in complex schemas. 
+
 ### Custom properties
 Specify your own JSON Schema properties with the validator.attributes property:
 

--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -58,8 +58,12 @@ validators.type = function validateType (instance, schema, options, ctx) {
   return result;
 };
 
-function testSchema(instance, options, ctx, schema){
-  return this.validateSchema(instance, schema, options, ctx).valid;
+function testSchema(instance, options, ctx, callback, schema){
+  var res = this.validateSchema(instance, schema, options, ctx);
+  if (! res.valid && callback instanceof Function) {
+    callback(res);
+  }
+  return res.valid;
 }
 
 /**
@@ -76,13 +80,18 @@ validators.anyOf = function validateAnyOf (instance, schema, options, ctx) {
     return null;
   }
   var result = new ValidatorResult(instance, schema, options, ctx);
+  var inner = new ValidatorResult(instance, schema, options, ctx);
   if (!Array.isArray(schema.anyOf)){
     throw new SchemaError("anyOf must be an array");
   }
-  if (!schema.anyOf.some(testSchema.bind(this, instance, options, ctx))) {
+  if (!schema.anyOf.some(
+    testSchema.bind(
+      this, instance, options, ctx, function(res){inner.importErrors(res);}
+      ))) {
     var list = schema.anyOf.map(function (v, i) {
       return (v.id && ('<' + v.id + '>')) || (v.title && JSON.stringify(v.title)) || (v['$ref'] && ('<' + v['$ref'] + '>')) || '[subschema '+i+']';
     });
+    result.importErrors(inner);
     result.addError({
       name: 'anyOf',
       argument: list,
@@ -142,11 +151,16 @@ validators.oneOf = function validateOneOf (instance, schema, options, ctx) {
     throw new SchemaError("oneOf must be an array");
   }
   var result = new ValidatorResult(instance, schema, options, ctx);
-  var count = schema.oneOf.filter(testSchema.bind(this, instance, options, ctx)).length;
+  var inner = new ValidatorResult(instance, schema, options, ctx);
+  var count = schema.oneOf.filter(
+    testSchema.bind(
+      this, instance, options, ctx, function(res) {inner.importErrors(res);}
+      ) ).length;
   var list = schema.oneOf.map(function (v, i) {
     return (v.id && ('<' + v.id + '>')) || (v.title && JSON.stringify(v.title)) || (v['$ref'] && ('<' + v['$ref'] + '>')) || '[subschema '+i+']';
   });
   if (count!==1) {
+    result.importErrors(inner);
     result.addError({
       name: 'oneOf',
       argument: list,

--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -91,7 +91,9 @@ validators.anyOf = function validateAnyOf (instance, schema, options, ctx) {
     var list = schema.anyOf.map(function (v, i) {
       return (v.id && ('<' + v.id + '>')) || (v.title && JSON.stringify(v.title)) || (v['$ref'] && ('<' + v['$ref'] + '>')) || '[subschema '+i+']';
     });
-    result.importErrors(inner);
+    if (options.nestedErrors) {
+      result.importErrors(inner);
+    }
     result.addError({
       name: 'anyOf',
       argument: list,
@@ -160,7 +162,9 @@ validators.oneOf = function validateOneOf (instance, schema, options, ctx) {
     return (v.id && ('<' + v.id + '>')) || (v.title && JSON.stringify(v.title)) || (v['$ref'] && ('<' + v['$ref'] + '>')) || '[subschema '+i+']';
   });
   if (count!==1) {
-    result.importErrors(inner);
+    if (options.nestedErrors) {
+      result.importErrors(inner);
+    }
     result.addError({
       name: 'oneOf',
       argument: list,


### PR DESCRIPTION
Per #189 -- `validateAnyOf` and `validateOneOf` now return full error stack, including root cause errors that result in the failures of `anyOf` and `oneOf`, similarly to the `allOf` treatment. This extra error information is useful for troubleshooting validation failures of moderately complex schemas.

