### PR TITLE
typescript: add throwError property to Options

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -94,6 +94,7 @@ export interface Options {
     rewrite?: RewriteFunction;
     propertyName?: string;
     base?: string;
+    throwError?: boolean;
 }
 
 export interface RewriteFunction {


### PR DESCRIPTION
`interface Options` was missing `throwError?: boolean`, causing this common pattern to fail to typecheck under TypeScript:

```typescript
validator.validate(obj, schema, { throwError: true })
```