### PR TITLE
Update ID detection for schemas

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -44,7 +44,7 @@ Validator.prototype.addSchema = function addSchema (schema, uri) {
   if (!schema) {
     return null;
   }
-  var ourUri = uri || schema.id;
+  var ourUri = uri || schema.$id || schema.id;
   this.addSubSchema(ourUri, schema);
   if (ourUri) {
     this.schemas[ourUri] = schema;


### PR DESCRIPTION
Based on the [latest spec](http://json-schema.org/latest/json-schema-core.html#rfc.section.9.2), the keyword that we want for the ID is `$id` instead of `id`

I kept the `schema.id` to be backward compatible but it prioritises `schema.$id`