### PR TITLE
Changing array type check from instanceof to Array.isArray()

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -315,7 +315,7 @@ types.boolean = function testBoolean (instance) {
   return typeof instance == 'boolean';
 };
 types.array = function testArray (instance) {
-  return instance instanceof Array;
+  return Array.isArray(instance);
 };
 types['null'] = function testNull (instance) {
   return instance === null;


### PR DESCRIPTION
This arose from me using the safe-eval library to evaluate js expressions that generate data which is later validated by jsonschema.  Below is the example code I have which demonstrates that an array generated by safe-eval causes `instance instanceof Array` to evaluate to false and fail validation, while `Array.isArray(instance)` evaluates to true.

```
let safeEval = require('safe-eval')
let Validator = require('jsonschema').Validator

let schema = {
  type: 'array',
  items: {
    type: 'integer'
  }
}

let instance, response

instance = [4]
res = new Validator().validate(instance, schema)
console.log("instanceof Array?", instance instanceof Array)  // true
console.log("Array.isArray()?", Array.isArray(instance))  // true
console.log('simple case, this works fine:', res) // valid: true


instance = safeEval('[4]')
res = new Validator().validate(instance, schema)
console.log("instanceof Array?", instance instanceof Array) // false
console.log("Array.isArray()?", Array.isArray(instance))  // true
console.log('array from safe-eval fails:', res) // valid: false
```