### PR TITLE
format field added to schema

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -83,6 +83,7 @@ export interface Schema {
     }
     'enum'?: any[]
     type?: string | string[]
+    format?: string
     allOf?: Schema[]
     anyOf?: Schema[]
     oneOf?: Schema[]


### PR DESCRIPTION
`format` field was missing in `Schema` interface.