### PR TITLE
show null value in enum error message

### DIFF
--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -782,7 +782,7 @@ validators['enum'] = function validateEnum (instance, schema, options, ctx) {
     result.addError({
       name: 'enum',
       argument: schema['enum'],
-      message: "is not one of enum values: " + schema['enum'].join(','),
+      message: "is not one of enum values: " + schema['enum'].map(String).join(','),
     });
   }
   return result;


### PR DESCRIPTION
## Issue
The current error message for an enum mismatch when the enum contains `null` doesn't show `null` because `Array.prototype.join()` uses an empty string to replace null or undefined values.

## Example
A mismatch with enum `[null,50000,100000,200000,300000]` gives the message `is not one of enum values: ,50000,100000,200000,300000`.

## Solution
The problem was fixed by mapping the enum values with the `String` method before using `join(,)`.