### PR TITLE
Fix style format validation for consecutive calls with the same instance

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -142,7 +142,7 @@ var FORMAT_REGEXPS = exports.FORMAT_REGEXPS = {
     }
     return result;
   },
-  'style': /\s*(.+?):\s*([^;]+);?/g,
+  'style': /\s*(.+?):\s*([^;]+);?/,
   'phone': /^\+(?:[0-9] ?){6,14}[0-9]$/
 };
 

--- a/test/formats.js
+++ b/test/formats.js
@@ -134,6 +134,11 @@ describe('Formats', function () {
       this.validator.validate("0", {'type': 'string', 'format': 'style'}).valid.should.be.false;
     });
 
+    it('should validate a valid style if called twice with the same instance', function () {
+      this.validator.validate("color: red;", {'type': 'string', 'format': 'style'}).valid.should.be.true;
+      this.validator.validate("color: red;", {'type': 'string', 'format': 'style'}).valid.should.be.true;
+    });
+
   });
 
   describe('phone', function () {


### PR DESCRIPTION
When you try to validate the same instance in two consecutive calls with the schema that includes `style` format, the second validation is going to fail.

Reason for that is described here: https://stackoverflow.com/questions/4950463/regex-in-javascript-fails-every-other-time-with-identical-input