### PR TITLE
fix issue with missing pattern in error message

### DIFF
--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -512,7 +512,7 @@ validators.pattern = function validatePattern (instance, schema, options, ctx) {
     result.addError({
       name: 'pattern',
       argument: schema.pattern,
-      message: "does not match pattern " + JSON.stringify(schema.pattern),
+      message: "does not match pattern " + JSON.stringify(schema.pattern.toString()),
     });
   }
   return result;

--- a/test/attributes.js
+++ b/test/attributes.js
@@ -250,6 +250,10 @@ describe('Attributes', function () {
     it('should validate if string does not match the string pattern', function () {
       return this.validator.validate('abac', {'type': 'string', 'pattern': 'ab+c'}).valid.should.be.false;
     });
+
+    it('should return correct error message when parsing regular expression', function () {
+        return this.validator.validate('abac', {'type': 'string', 'pattern': /^a+$/}).errors[0].stack.should.include("/^a+$/");
+    })
   });
 
   describe('minLength', function () {


### PR DESCRIPTION
Currently when attempting to validate input based on regular expressions I faced the following

`"pattern": "does not match pattern {}"`

I noticed that this happens only when I put regular expressions in the following way:
`let pattern = /^a+b$/`

Because JSON.stringify does not support regular expressions, it returns `{}` which doesn't tell our application user about root cause of the problem.

I tried to apply `toString` method on regular expressions to avoid this kind of behaviour. 