### PR TITLE
update types: pattern can be RegExp

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -60,7 +60,7 @@ export interface Schema {
     exclusiveMinimum?: boolean
     maxLength?: number
     minLength?: number
-    pattern?: string
+    pattern?: string | RegExp
     additionalItems?: boolean | Schema
     items?: Schema | Schema[]
     maxItems?: number


### PR DESCRIPTION
The `pattern` prop of a schema can be a string or `RegExp`, this updates the types file to reflect that.