### PR TITLE
fix type for Schema.required

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -68,7 +68,7 @@ export interface Schema {
     uniqueItems?: boolean
     maxProperties?: number
     minProperties?: number
-    required?: string[]
+    required?: string[] | boolean
     additionalProperties?: boolean | Schema
     definitions?: {
         [name: string]: Schema


### PR DESCRIPTION
the `required` property can be either an array of strings, or a boolean, as per the example docs: https://github.com/tdegrunt/jsonschema/blob/9cb2cf847a33abb76b694c6ed4d8d12ef2037201/examples/all.js#L116-L147

Fixes #291.