### PR TITLE
Add nestedErrors to TypeScript declaration of Options

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -98,6 +98,7 @@ export interface Options {
     propertyName?: string;
     base?: string;
     throwError?: boolean;
+    nestedErrors?: boolean;
 }
 
 export interface RewriteFunction {


### PR DESCRIPTION
The TypeScript declaration for the Options class lacks the `nestedErrors` property,
despite it is being supported internally. This makes the library a little friendlier to use
in *TypeScript* applications that want to use this feature.