### PR TITLE
Improved additionalProperty error message

### DIFF
--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -219,7 +219,7 @@ function testAdditionalProperty (instance, schema, options, ctx, property, resul
     result.addError({
       name: 'additionalProperties',
       argument: property,
-      message: "is not allowed to have the property " + JSON.stringify(property),
+      message: "is not allowed to have the additional property " + JSON.stringify(property),
     });
   } else {
     var additionalProperties = schema.additionalProperties || {};

--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -219,7 +219,7 @@ function testAdditionalProperty (instance, schema, options, ctx, property, resul
     result.addError({
       name: 'additionalProperties',
       argument: property,
-      message: "additionalProperty " + JSON.stringify(property) + " exists in instance when not allowed",
+      message: "is not allowed to have the property " + JSON.stringify(property),
     });
   } else {
     var additionalProperties = schema.additionalProperties || {};


### PR DESCRIPTION
This makes the error message and stack to be more human-readable. The stack reads:

```js
// Current:
instance.body additionalProperty "abc" exists in instance when not allowed

// Proposed in this PR:
instance.body is not allowed to have the additional property "abc"
```


For this object and schema:

```js
const body = { body: { abc: "def" } };
const schema = {
  type: "object",
  properties: {
    body: {
      additionalProperties: false
    }
  }
};
```

Current error and stack:

```js
ValidationError {
  property: 'instance.body',
  message: 'additionalProperty "abc" exists in instance when not allowed',
  schema: { additionalProperties: false },
  instance: { abc: 'def' },
  name: 'additionalProperties',
  argument: 'abc',
  stack: 'instance.body additionalProperty "abc" exists in instance when not allowed'
}
```

Proposed in this PR:

```js
ValidationError {
  property: 'instance.body',
  message: 'is not allowed to have the additional property "abc"',
  schema: { additionalProperties: false },
  instance: { abc: 'def' },
  name: 'additionalProperties',
  argument: 'abc',
  stack: 'instance.body is not allowed to have the additional property "abc"'
}
```