### PR TITLE
Add check that uniqueItems is set to false

### DIFF
--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -634,32 +634,6 @@ validators.maxItems = function validateMaxItems (instance, schema, options, ctx)
 };
 
 /**
- * Validates that every item in an instance array is unique, when instance is an array
- * @param instance
- * @param schema
- * @param options
- * @param ctx
- * @return {String|null|ValidatorResult}
- */
-validators.uniqueItems = function validateUniqueItems (instance, schema, options, ctx) {
-  if (!this.types.array(instance)) return;
-  var result = new ValidatorResult(instance, schema, options, ctx);
-  function testArrays (v, i, a) {
-    for (var j = i + 1; j < a.length; j++) if (helpers.deepCompareStrict(v, a[j])) {
-      return false;
-    }
-    return true;
-  }
-  if (!instance.every(testArrays)) {
-    result.addError({
-      name: 'uniqueItems',
-      message: "contains duplicate item",
-    });
-  }
-  return result;
-};
-
-/**
  * Deep compares arrays for duplicates
  * @param v
  * @param i
@@ -684,6 +658,8 @@ function testArrays (v, i, a) {
  */
 validators.uniqueItems = function validateUniqueItems (instance, schema, options, ctx) {
   if (!this.types.array(instance)) return;
+  // Abort if uniqueItems is set explicitly to something falsy
+  if (!schema.uniqueItems) return;
   var result = new ValidatorResult(instance, schema, options, ctx);
   if (!instance.every(testArrays)) {
     result.addError({

--- a/test/arrays.js
+++ b/test/arrays.js
@@ -94,5 +94,13 @@ describe('Arrays', function () {
     it('should validate if not an Array', function () {
       return this.validator.validate(null, {'type': 'any', 'uniqueItems': true}).valid.should.be.true;
     });
+
+    it('shouldvalidate if array has no duplicate items and uniqueItems is false', function () {
+      return this.validator.validate([1, 2, 3], {'type': 'array', 'uniqueItems': false}).valid.should.be.true;
+    });
+
+    it('should validate if array has duplicate numbers but uniqueItems is false', function () {
+      return this.validator.validate([1, 2, 4, 1, 3, 5], {'type': 'array', 'uniqueItems': false}).valid.should.be.true;
+    });
   });
 });


### PR DESCRIPTION
Should close https://github.com/tdegrunt/jsonschema/issues/299

Should detect cases of `{ uniqueItems: false }`. I've added some simple tests for this and they pass for me locally running `npm test`.

Also removes what seems to be a duplicate definition of the `validators.uniqueItems` property. The implementation were almost the same but not quite. If you think the one I deleted was actually the more correct one I can change it around.

Looking at https://github.com/json-schema-org/JSON-Schema-Test-Suite/pull/338 it seems like some changes will be needed there but I'm not sure exactly what or how to coordinate it between the two repos. I'm happy to make the extra changes there if you like or you're welcome to do it yourself if that's easier.