### PR TITLE
Fix exclusive minimum boolean check in function validateExclusiveMinimum 

### DIFF
--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -554,7 +554,7 @@ validators.maximum = function validateMaximum (instance, schema, options, ctx) {
  */
 validators.exclusiveMinimum = function validateExclusiveMinimum (instance, schema, options, ctx) {
   // Support the boolean form of exclusiveMinimum, which is handled by the "minimum" keyword.
-  if(typeof schema.exclusiveMaximum === 'boolean') return;
+  if(typeof schema.exclusiveMinimum === 'boolean') return;
   if (!this.types.number(instance)) return;
   var result = new ValidatorResult(instance, schema, options, ctx);
   var valid = instance > schema.exclusiveMinimum;

--- a/test/attributes.js
+++ b/test/attributes.js
@@ -214,7 +214,7 @@ describe('Attributes', function () {
     });
 
     it('should validate if number is above minimum, using exclusiveMinimum', function () {
-      return this.validator.validate(2, {'type': 'number', 'minimum': '1', 'exclusiveMinimum': true}).valid.should.be.true;
+      return this.validator.validate(1, {'type': 'number', 'minimum': '0', 'exclusiveMinimum': true}).valid.should.be.true;
     });
 
     it('should not validate if number is the minimum, using exclusiveMinimum', function () {


### PR DESCRIPTION
The following example resulted in an error before:

```
this.validator.validate(1, { 'type': 'number', 'exclusiveMinimum': true, 'minimum': 0 })
```

The reason for it was that function validateExclusiveMinimum checked `(typeof schema.exclusiveMaximum === 'boolean')` but not `(typeof schema.exclusiveMinimum === 'boolean')`. The issue will be fixed with this change.

I have adjusted the corresponding test case in this context to also cover this edge case as in most cases the old implementation still returned the right value despite the bug.

Hope you can integrate this fix soon to avoid annoying workarounds for me.