### PR TITLE
Add makeChild type to SchemaContext interface

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -123,6 +123,7 @@ export interface SchemaContext {
     propertyPath: string;
     base: string;
     schemas: {[base: string]: Schema};
+    makeChild: (schema: Schema, key: string) => SchemaContext;
 }
 
 export interface CustomFormat {


### PR DESCRIPTION
This allows TypeScript users to follow the [Pre-Property Validation](https://github.com/tdegrunt/jsonschema#pre-property-validation-hook) hook example and implement their own version of it.