### PR TITLE
Define SchemaContext path type

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -121,6 +121,7 @@ export interface PreValidatePropertyFunction {
 export interface SchemaContext {
     schema: Schema;
     options: Options;
+    path: (number | string)[];
     propertyPath: string;
     base: string;
     schemas: {[base: string]: Schema};


### PR DESCRIPTION
This property exists, but it was missing in the type definitions.