### PR TITLE
Fix "maximum call stack size exceeded" when there are many errors

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -67,7 +67,7 @@ ValidatorResult.prototype.importErrors = function importErrors(res) {
   if (typeof res == 'string' || (res && res.validatorType)) {
     this.addError(res);
   } else if (res && res.errors) {
-    Array.prototype.push.apply(this.errors, res.errors);
+    this.errors = this.errors.concat(res.errors)
   }
 };
 

--- a/test/Validator.test.js
+++ b/test/Validator.test.js
@@ -6,6 +6,7 @@
 var Validator = require('../lib/index.js').Validator;
 var SchemaError = require('../lib/index.js').SchemaError;
 var ValidationError = require('../lib/index.js').ValidationError;
+var ValidatorResult = require('../lib/index.js').ValidatorResult;
 var ValidatorResultError = require('../lib/index.js').ValidatorResultError;
 var assert = require('assert');
 
@@ -281,6 +282,22 @@ describe('Validator', function () {
         assert.strictEqual(err.errors.length, 2);
         return true;
       });
+    });
+    it('million errors', function () {
+      var schema = {
+        type: 'number',
+        oneMillionErrors: true,
+      };
+      validator.attributes.oneMillionErrors = function(instance, schema, options, ctx) {
+        const result = new ValidatorResult(instance, schema, options, ctx);
+        for(var i = 0; i < 1000000; i++) {
+          result.addError('oneMillionErrors error');
+        }
+        return result;
+      }
+      var res = validator.validate(1, schema, {});
+      assert(!res.valid);
+      assert.strictEqual(res.errors.length, 1000000);
     });
     it('subschema references (named reference)', function () {
       var schema = {


### PR DESCRIPTION
Fixes #344.

Note: The included test simulates one million errors. To keep the tests running fast it does so using a custom keyword to produce all of the errors. This approach was over 7x faster than my efforts to use built-in keywords and large arrays/objects, but it still takes around 300ms on my laptop.