### PR TITLE
add optional onError callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ The validator can be configured to throw in the event of a validation error:
 
 * If the `throwError` option is set, it will throw at the first encountered validation error (like `throwFirst`), but the `ValidationError` object itself will be thrown. Note that, despite the name, this does not inherit from Error like `ValidatorResultError` does.
 
+* If the `onError` option is set, the validator will call the provided callback with the `ValidationError` object.
+
 The `ValidatorResultError` object has the same properties as `ValidatorResult` and additionally inherits from Error.
 
 #### "nestedErrors" option

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -40,6 +40,7 @@ var ValidatorResult = exports.ValidatorResult = function ValidatorResult(instanc
   this.throwError = options && options.throwError;
   this.throwFirst = options && options.throwFirst;
   this.throwAll = options && options.throwAll;
+  this.onError = options && options.onError;
   this.disableFormat = options && options.disableFormat === true;
 };
 
@@ -59,6 +60,9 @@ ValidatorResult.prototype.addError = function addError(detail) {
     throw new ValidatorResultError(this);
   }else if(this.throwError){
     throw err;
+  }
+  if(this.onError) {
+    this.onError(err)
   }
   return err;
 };

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -107,6 +107,7 @@ export interface Options {
     required?: boolean;
     throwFirst?: boolean;
     throwAll?: boolean;
+    onError?: (err: ValidationError) => void;
     nestedErrors?: boolean;
 }
 

--- a/test/Validator.test.js
+++ b/test/Validator.test.js
@@ -282,6 +282,19 @@ describe('Validator', function () {
         return true;
       });
     });
+    it('options.onError', function () {
+      var schema = {
+        type: 'array',
+        items: {type: 'number'},
+      }
+      var errors = []
+      validator.validate([0,'1','2',3,4], schema, {
+        onError: function (err) {
+          errors.push(err)
+        }
+      });
+      assert.strictEqual(errors.length, 2);
+    });
     it('subschema references (named reference)', function () {
       var schema = {
         items: {$ref: '#items'},


### PR DESCRIPTION
This is an enhancement request + PR in one:

The goal is to stop validating after 200 errors.  Instead of hard-coding that number, and instead of a specific option like `throwAfter: 200`, a generic `onError` callback can be the building block to enable this.

To stop after 200 errors we could do something like this: `onError: () => { if (++count >= 200) { throw ... } }`.
