### PR TITLE
docs: fix incorrect formatting in example array schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,17 +82,17 @@ console.log(v.validate(p, schema));
 ```
 ### Example for Array schema
 
-```json
+```js
 var arraySchema = {
-        "type": "array",
-        "items": {
-            "properties": {
-                "name": { "type": "string" },
-                "lastname": { "type": "string" }
-            },
-            "required": ["name", "lastname"]
-        }
-    }
+  "type": "array",
+  "items": {
+    "properties": {
+      "name": { "type": "string" },
+      "lastname": { "type": "string" }
+    },
+    "required": ["name", "lastname"]
+  }
+};
 ```
 For a comprehensive, annotated example illustrating all possible validation options, see [examples/all.js](./examples/all.js)
 


### PR DESCRIPTION
There's a Javascript snippet incorrectly labeled as JSON in the markdown. This causes Github to display it highlighted in red, as if the was a syntax error.

Changing it to JS show the correct formatting. I also removed the extra spaces so that the formatting is consistent with the other examples in the readme:

Before|After
------|-----
![Screen Shot 2022-08-23 at 4 43 08 PM](https://user-images.githubusercontent.com/8048702/186272145-de2eaed6-dd87-4ea9-9db2-2dd9c66d18fe.png)|![Screen Shot 2022-08-23 at 4 43 11 PM](https://user-images.githubusercontent.com/8048702/186272157-c39fe9d8-e127-4a65-bd9d-5ae1b2b0f585.png)

