### PR TITLE
Fixing throwFirst for combinators.

### DIFF
--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -63,11 +63,14 @@ validators.type = function validateType (instance, schema, options, ctx) {
 function testSchemaNoThrow(instance, options, ctx, callback, schema){
   var throwError = options.throwError;
   var throwAll = options.throwAll;
+  var throwFirst = options.throwFirst;
   options.throwError = false;
   options.throwAll = false;
+  options.throwFirst = false;
   var res = this.validateSchema(instance, schema, options, ctx);
   options.throwError = throwError;
   options.throwAll = throwAll;
+  options.throwFirst = throwFirst;
 
   if (!res.valid && callback instanceof Function) {
     callback(res);

--- a/test/combinators.js
+++ b/test/combinators.js
@@ -42,6 +42,12 @@ describe('Combinators', function () {
       }.bind(this)).should.not.throw();
     });
 
+    it('should not throw if valid when throwFirst is set', function () {
+      (function() {
+        this.validator.validate({ 'name': 'test2' }, this.schema, { throwFirst: true });
+      }.bind(this)).should.not.throw();
+    });
+
     it('should throw if invalid when throwError is set', function () {
       (function() {
         this.validator.validate({ 'name': 'test3' }, this.schema, { throwError: true });
@@ -78,6 +84,12 @@ describe('Combinators', function () {
     it('should not throw if valid when throwError is set', function () {
       (function() {
         this.validator.validate({ 'name2': 'test2' }, this.schema, { throwError: true });
+      }.bind(this)).should.not.throw();
+    });
+
+    it('should not throw if valid when throwFirst is set', function () {
+      (function() {
+        this.validator.validate({ 'name2': 'test2' }, this.schema, { throwFirst: true });
       }.bind(this)).should.not.throw();
     });
 


### PR DESCRIPTION
When I used `throwFirst` option and `oneOf` combinators an error is thrown despite the schema being valid. I have provided two new test cases which fail without the given fix.

Thank you for maintaining the library.