### PR TITLE
fix: add draft-6 examples array

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -104,6 +104,7 @@ export interface Schema {
     then?: Schema
     else?: Schema
     default?: any
+    examples?: any[]
 }
 
 export interface Options {


### PR DESCRIPTION
# Problem

`examples` missing, part of draft-6 spec (https://www.learnjsonschema.com/2020-12/meta-data/examples/)

# Solution

Add 'em!