### PR TITLE
Added contains to Schema type in index.ts

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -72,6 +72,7 @@ export interface Schema {
     pattern?: string | RegExp
     additionalItems?: boolean | Schema
     items?: Schema | Schema[]
+    contains: Schema
     maxItems?: number
     minItems?: number
     uniqueItems?: boolean

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -72,7 +72,7 @@ export interface Schema {
     pattern?: string | RegExp
     additionalItems?: boolean | Schema
     items?: Schema | Schema[]
-    contains: Schema
+    contains?: Schema
     maxItems?: number
     minItems?: number
     uniqueItems?: boolean


### PR DESCRIPTION
The contains keyword can be used and used in js.
But the Schema type is missing 'contains' keyword.
So I added it to support it in typescript