### PR TITLE
Fix/add contains to schema type

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -72,6 +72,7 @@ export interface Schema {
     pattern?: string | RegExp
     additionalItems?: boolean | Schema
     items?: Schema | Schema[]
+    contains: Schema
     maxItems?: number
     minItems?: number
     uniqueItems?: boolean

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -72,7 +72,7 @@ export interface Schema {
     pattern?: string | RegExp
     additionalItems?: boolean | Schema
     items?: Schema | Schema[]
-    contains: Schema
+    contains?: Schema
     maxItems?: number
     minItems?: number
     uniqueItems?: boolean


### PR DESCRIPTION
Added 'contains' keyword to Schema type in index.ts
The contains implemented already in js, but never was added to the types