### PR TITLE
Use web URL API instead of Node URL library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "test/suite"]
 	path = test/suite
-	url = git://github.com/json-schema-org/JSON-Schema-Test-Suite.git
+	url = https://github.com/json-schema-org/JSON-Schema-Test-Suite.git

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -129,23 +129,13 @@ var SchemaContext = exports.SchemaContext = function SchemaContext (schema, opti
 };
 
 SchemaContext.prototype.resolve = function resolve (target) {
-  const resolvedUrl = new URL(target, new URL(this.base, 'resolve://'));
-  if (resolvedUrl.protocol === 'resolve:') {
-    const { pathname, search, hash } = resolvedUrl;
-    return pathname + search + hash;
-  }
-  return resolvedUrl.toString();
+  return (() => resolveUrl(this.base,target))();
 };
 
 SchemaContext.prototype.makeChild = function makeChild(schema, propertyName){
   var path = (propertyName===undefined) ? this.path : this.path.concat([propertyName]);
   var id = schema.$id || schema.id;
-  let base = new URL(id||'', new URL(this.base, 'resolve://'));
-  if (base.protocol === 'resolve:') {
-    const { pathname, search, hash } = base;
-    base = pathname + search + hash;
-  }
-  base = base.toString();
+  let base = (() => resolveUrl(this.base,id||''))();
   var ctx = new SchemaContext(schema, this.options, path, base, Object.create(this.schemas));
   if(id && !ctx.schemas[base]){
     ctx.schemas[base] = schema;
@@ -398,3 +388,19 @@ exports.isSchema = function isSchema(val){
   return (typeof val === 'object' && val) || (typeof val === 'boolean');
 };
 
+/**
+ * Resolve target URL from a base and relative URL.
+ * Similar to Node's URL Lib's legacy resolve function.
+ * Code from example in deprecation note in said library.
+ * @param string
+ * @param string
+ * @returns {string}
+ */
+var resolveUrl = exports.resolveUrl = function resolveUrl(from, to) {
+  const resolvedUrl = new URL(to, new URL(from, 'resolve://'));
+  if (resolvedUrl.protocol === 'resolve:') {
+    const { pathname, search, hash } = resolvedUrl;
+    return pathname + search + hash;
+  }
+  return resolvedUrl.toString();
+}

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var uri = require('url');
-
 var ValidationError = exports.ValidationError = function ValidationError (message, instance, schema, path, name, argument) {
   if(Array.isArray(path)){
     this.path = path;
@@ -131,13 +129,24 @@ var SchemaContext = exports.SchemaContext = function SchemaContext (schema, opti
 };
 
 SchemaContext.prototype.resolve = function resolve (target) {
-  return uri.resolve(this.base, target);
+  const resolvedUrl = new URL(target, new URL(this.base, 'resolve://'));
+  if (resolvedUrl.protocol === 'resolve:') {
+    const { pathname, search, hash } = resolvedUrl;
+    return pathname + search + hash;
+  }
+  return resolvedUrl.toString();
 };
 
 SchemaContext.prototype.makeChild = function makeChild(schema, propertyName){
   var path = (propertyName===undefined) ? this.path : this.path.concat([propertyName]);
   var id = schema.$id || schema.id;
-  var base = uri.resolve(this.base, id||'');
+  //var base = uri.resolve(this.base, id||'');
+  let base = new URL(id||'', new URL(this.base, 'resolve://'));
+  if (base.protocol === 'resolve:') {
+    const { pathname, search, hash } = base;
+    base = pathname + search + hash;
+  }
+  base = base.toString();
   var ctx = new SchemaContext(schema, this.options, path, base, Object.create(this.schemas));
   if(id && !ctx.schemas[base]){
     ctx.schemas[base] = schema;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -140,7 +140,6 @@ SchemaContext.prototype.resolve = function resolve (target) {
 SchemaContext.prototype.makeChild = function makeChild(schema, propertyName){
   var path = (propertyName===undefined) ? this.path : this.path.concat([propertyName]);
   var id = schema.$id || schema.id;
-  //var base = uri.resolve(this.base, id||'');
   let base = new URL(id||'', new URL(this.base, 'resolve://'));
   if (base.protocol === 'resolve:') {
     const { pathname, search, hash } = base;

--- a/lib/scan.js
+++ b/lib/scan.js
@@ -19,24 +19,12 @@ module.exports.scan = function scan(base, schema){
     if(!schema || typeof schema!='object') return;
     // Mark all referenced schemas so we can tell later which schemas are referred to, but never defined
     if(schema.$ref){
-      let resolvedUri = new URL(schema.$ref, new URL(baseuri, 'resolve://'));
-      if (resolvedUri.protocol === 'resolve:') {
-        const { pathname, search, hash } = resolvedUri;
-        resolvedUri = pathname + search + hash;
-      }
-      resolvedUri = resolvedUri.toString();
+      let resolvedUri = helpers.resolveUrl(baseuri,schema.$ref);
       ref[resolvedUri] = ref[resolvedUri] ? ref[resolvedUri]+1 : 0;
       return;
     }
     var id = schema.$id || schema.id;
-
-    let resolvedBase = new URL(id, new URL(baseuri, 'resolve://'));
-    if (resolvedBase.protocol === 'resolve:') {
-      const { pathname, search, hash } = resolvedBase;
-      resolvedBase = pathname + search + hash;
-    }
-    resolvedBase = resolvedBase.toString();
-
+    let resolvedBase = helpers.resolveUrl(baseuri,id);
     var ourBase = id ? resolvedBase : baseuri;
     if (ourBase) {
       // If there's no fragment, append an empty one

--- a/lib/scan.js
+++ b/lib/scan.js
@@ -1,6 +1,5 @@
 "use strict";
 
-var urilib = require('url');
 var helpers = require('./helpers');
 
 module.exports.SchemaScanResult = SchemaScanResult;
@@ -20,12 +19,25 @@ module.exports.scan = function scan(base, schema){
     if(!schema || typeof schema!='object') return;
     // Mark all referenced schemas so we can tell later which schemas are referred to, but never defined
     if(schema.$ref){
-      var resolvedUri = urilib.resolve(baseuri, schema.$ref);
+      let resolvedUri = new URL(schema.$ref, new URL(baseuri, 'resolve://'));
+      if (resolvedUri.protocol === 'resolve:') {
+        const { pathname, search, hash } = resolvedUri;
+        resolvedUri = pathname + search + hash;
+      }
+      resolvedUri = resolvedUri.toString();
       ref[resolvedUri] = ref[resolvedUri] ? ref[resolvedUri]+1 : 0;
       return;
     }
     var id = schema.$id || schema.id;
-    var ourBase = id ? urilib.resolve(baseuri, id) : baseuri;
+
+    let resolvedBase = new URL(id, new URL(baseuri, 'resolve://'));
+    if (resolvedBase.protocol === 'resolve:') {
+      const { pathname, search, hash } = resolvedBase;
+      resolvedBase = pathname + search + hash;
+    }
+    resolvedBase = resolvedBase.toString();
+
+    var ourBase = id ? resolvedBase : baseuri;
     if (ourBase) {
       // If there's no fragment, append an empty one
       if(ourBase.indexOf('#')<0) ourBase += '#';

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -115,7 +115,12 @@ Validator.prototype.validate = function validate (instance, schema, options, ctx
   // This section indexes subschemas in the provided schema, so they don't need to be added with Validator#addSchema
   // This will work so long as the function at uri.resolve() will resolve a relative URI to a relative URI
   var id = schema.$id || schema.id;
-  var base = urilib.resolve(options.base||anonymousBase, id||'');
+  let base = new URL(id||'', new URL(options.base||anonymousBase, 'resolve://'));
+  if(base.protocol === 'resolve:'){
+    const { pathname, search, hash } = base;
+    base = pathname + search + hash;
+  }
+  base = String(base)
   if(!ctx){
     ctx = new SchemaContext(schema, options, [], base, Object.create(this.schemas));
     if (!ctx.schemas[base]) {
@@ -262,8 +267,8 @@ Validator.prototype.resolve = function resolve (schema, switchSchema, ctx) {
     return {subschema: ctx.schemas[switchSchema], switchSchema: switchSchema};
   }
   // Else try walking the property pointer
-  var parsed = urilib.parse(switchSchema);
-  var fragment = parsed && parsed.hash;
+  let parsed = new URL(switchSchema,'thismessage::/');
+  let fragment = parsed.hash;
   var document = fragment && fragment.length && switchSchema.substr(0, switchSchema.length - fragment.length);
   if (!document || !ctx.schemas[document]) {
     throw new SchemaError("no such schema <" + switchSchema + ">", schema);

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -113,12 +113,7 @@ Validator.prototype.validate = function validate (instance, schema, options, ctx
   // This section indexes subschemas in the provided schema, so they don't need to be added with Validator#addSchema
   // This will work so long as the function at uri.resolve() will resolve a relative URI to a relative URI
   var id = schema.$id || schema.id;
-  let base = new URL(id||'', new URL(options.base||anonymousBase, 'resolve://'));
-  if(base.protocol === 'resolve:'){
-    const { pathname, search, hash } = base;
-    base = pathname + search + hash;
-  }
-  base = base.toString();
+  let base = helpers.resolveUrl(options.base,id||'');
   if(!ctx){
     ctx = new SchemaContext(schema, options, [], base, Object.create(this.schemas));
     if (!ctx.schemas[base]) {

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -118,7 +118,7 @@ Validator.prototype.validate = function validate (instance, schema, options, ctx
     const { pathname, search, hash } = base;
     base = pathname + search + hash;
   }
-  base = String(base)
+  base = String(base);
   if(!ctx){
     ctx = new SchemaContext(schema, options, [], base, Object.create(this.schemas));
     if (!ctx.schemas[base]) {

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -118,7 +118,7 @@ Validator.prototype.validate = function validate (instance, schema, options, ctx
     const { pathname, search, hash } = base;
     base = pathname + search + hash;
   }
-  base = String(base);
+  base = base.toString();
   if(!ctx){
     ctx = new SchemaContext(schema, options, [], base, Object.create(this.schemas));
     if (!ctx.schemas[base]) {

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var urilib = require('url');
-
 var attribute = require('./attribute');
 var helpers = require('./helpers');
 var scanSchema = require('./scan').scan;


### PR DESCRIPTION
Addresses #395, #393, #367, and [#20](https://github.com/SuperFlyTV/GraphicsDataDefinition/issues/20). Motivated generally by wanting to frictionlessly use jsonschema while prototyping with Vite. 

2764 tests passed, 9 pending, same as before changes. 

I am looking at making a resolve helper method instead of duplicating logic everywhere, but I need to educate myself on JS scoping stuff before making it work. 

I also changed the test suite submodule URL to https from git, I think submodule init for it will work whether or not you SSH'd or HTTPS'd the repo. I'll happily revert if that's more appropriate for a seperate PR or git syntax is preffered. 