### PR TITLE
perf: skip no-op URL resolution in makeChild and memoize makeSuffix (2.3x)

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -135,7 +135,16 @@ SchemaContext.prototype.resolve = function resolve (target) {
 SchemaContext.prototype.makeChild = function makeChild(schema, propertyName){
   var path = (propertyName===undefined) ? this.path : this.path.concat([propertyName]);
   var id = schema.$id || schema.id;
-  let base = (() => resolveUrl(this.base,id||''))();
+  var base = this.base;
+  if (id) {
+    base = resolveUrl(base, id);
+  } else {
+    // resolveUrl(base, '') only ever normalizes away a fragment here (the base is
+    // already resolveUrl output), so do that directly instead of constructing two
+    // URL objects per visited property.
+    var hashIndex = base.indexOf('#');
+    if (hashIndex !== -1) base = base.substring(0, hashIndex);
+  }
   var ctx = new SchemaContext(schema, this.options, path, base, Object.create(this.schemas));
   if(id && !ctx.schemas[base]){
     ctx.schemas[base] = schema;
@@ -226,18 +235,29 @@ exports.isFormat = function isFormat (input, format, validator) {
   return true;
 };
 
+var makeSuffixCache = new Map();
 var makeSuffix = exports.makeSuffix = function makeSuffix (key) {
   key = key.toString();
+  if (makeSuffixCache.has(key)) {
+    return makeSuffixCache.get(key);
+  }
   // This function could be capable of outputting valid a ECMAScript string, but the
   // resulting code for testing which form to use would be tens of thousands of characters long
   // That means this will use the name form for some illegal forms
+  var suffix;
   if (!key.match(/[.\s\[\]]/) && !key.match(/^[\d]/)) {
-    return '.' + key;
+    suffix = '.' + key;
+  } else if (key.match(/^\d+$/)) {
+    suffix = '[' + key + ']';
+  } else {
+    suffix = '[' + JSON.stringify(key) + ']';
   }
-  if (key.match(/^\d+$/)) {
-    return '[' + key + ']';
+  // Bound the cache so pathologically diverse keys (e.g. validating instances with
+  // huge numbers of distinct property names) can't grow it without limit.
+  if (makeSuffixCache.size < 100000) {
+    makeSuffixCache.set(key, suffix);
   }
-  return '[' + JSON.stringify(key) + ']';
+  return suffix;
 };
 
 exports.deepCompareStrict = function deepCompareStrict (a, b) {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,70 @@
+'use strict';
+
+/*jsl predef:define*/
+/*jsl predef:it*/
+
+var assert = require('assert');
+var helpers = require('../lib/helpers.js');
+var Validator = require('../lib/index.js').Validator;
+
+describe('helpers', function () {
+  describe('SchemaContext#makeChild', function () {
+    it('resolves the child base against the parent when the child has an id', function () {
+      var ctx = new helpers.SchemaContext({}, {}, [], 'http://example.com/foo.json', {});
+      var childSchema = {$id: 'bar.json'};
+      var child = ctx.makeChild(childSchema, 'bar');
+      assert.strictEqual(child.base, 'http://example.com/bar.json');
+      assert.strictEqual(child.schemas['http://example.com/bar.json'], childSchema);
+    });
+
+    it('strips a fragment from an id-less child base instead of leaving it untouched', function () {
+      var ctx = new helpers.SchemaContext({}, {}, [], 'http://example.com/foo.json#/some/frag', {});
+      var child = ctx.makeChild({type: 'string'}, 'prop');
+      assert.strictEqual(child.base, 'http://example.com/foo.json');
+    });
+
+    it('leaves a fragment-free id-less child base unchanged', function () {
+      var ctx = new helpers.SchemaContext({}, {}, [], 'http://example.com/foo.json', {});
+      var child = ctx.makeChild({type: 'string'}, 'prop');
+      assert.strictEqual(child.base, 'http://example.com/foo.json');
+    });
+
+    it('still resolves refs correctly when a subschema declares its own id', function () {
+      var validator = new Validator();
+      var schema = {
+        items: {$ref: '#items'},
+        definitions: {
+          items: {
+            $id: '#items',
+            type: 'array',
+          },
+        },
+      };
+      var res = validator.validate([[]], schema);
+      assert(res.valid);
+      var neg = validator.validate([null], schema);
+      assert(!neg.valid);
+    });
+  });
+
+  describe('makeSuffix', function () {
+    it('returns identical output for repeated calls with a dotted-form key', function () {
+      assert.strictEqual(helpers.makeSuffix('foo'), '.foo');
+      assert.strictEqual(helpers.makeSuffix('foo'), '.foo');
+    });
+
+    it('returns identical output for repeated calls with a numeric key', function () {
+      assert.strictEqual(helpers.makeSuffix(3), '[3]');
+      assert.strictEqual(helpers.makeSuffix(3), '[3]');
+      assert.strictEqual(helpers.makeSuffix('42'), '[42]');
+      assert.strictEqual(helpers.makeSuffix('42'), '[42]');
+    });
+
+    it('returns identical output for repeated calls with a key needing JSON.stringify quoting', function () {
+      assert.strictEqual(helpers.makeSuffix('a.b'), '["a.b"]');
+      assert.strictEqual(helpers.makeSuffix('a.b'), '["a.b"]');
+      assert.strictEqual(helpers.makeSuffix('has space'), '["has space"]');
+      assert.strictEqual(helpers.makeSuffix('has space'), '["has space"]');
+    });
+  });
+});


### PR DESCRIPTION
While profiling a production Node.js service, this library showed up as the largest single CPU cost centre on the main thread (~20% of on-CPU time), and nearly all of it traced to two lines. This PR fixes both; measured end to end on a large real-world schema set (16 subschemas, documents with hundreds of nodes), validation is **2.3x faster** (3000 validations: 34.6s -> 14.8s, Node 26).

**1. `makeChild` resolves a URL even when there is nothing to resolve.**

```js
let base = (() => resolveUrl(this.base, id || ''))();
```

This runs for every property visited in every validation, and `resolveUrl` constructs two `URL` objects per call. Since the overwhelming majority of subschemas carry no `id`/`$id`, almost every call builds and discards two URLs to recompute a value it already has. The only thing `resolveUrl(base, '')` can actually change is stripping a fragment from the base (every base in the system is already `resolveUrl` output, hence already normalized), so the id-less path now does exactly that with a string operation instead.

**2. `makeSuffix` re-runs two regex matches per path element at every node.** The property path string is rebuilt at every schema node, over a small recurring vocabulary of keys, so the results are now memoized in a size-bounded `Map`.

**Behavior preservation:** the new tests in `test/helpers.js` (id-bearing child resolution, fragment-stripping on id-less children, `$id`/`$ref` end-to-end, `makeSuffix` stability for dotted/numeric/quotable keys) were run against the **unmodified** library first and all passed, then again after the change. Full suite: 2771 passing, 9 pending (the pre-existing skips), 0 failing.

Related: this also routes the id-less hot path around the `new URL()` construction implicated in #405 and #407 — it does not fix those reports (the id-bearing and ref-resolution paths still construct URLs), but it removes the vast majority of the calls that hit that code.

Note for maintainers running the suite on current Node: mocha 11's pinned `yargs@16` crashes on Node >= 22 with `require is not defined in ES module scope` before any test runs — unrelated to this change.
