### PR TITLE
Resolve local $ref fragments without a URL parse against an opaque base (fixes #423)

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -259,9 +259,12 @@ Validator.prototype.resolve = function resolve (schema, switchSchema, ctx) {
   if (ctx.schemas[switchSchema]) {
     return {subschema: ctx.schemas[switchSchema], switchSchema: switchSchema};
   }
-  // Else try walking the property pointer
-  let parsed = new URL(switchSchema,'thismessage::/');
-  let fragment = parsed.hash;
+  // Else try walking the property pointer. Split the fragment off by hand:
+  // `switchSchema` may be a bare path such as "/undefined#/$defs/x", which is
+  // not a valid relative reference against an opaque-path base and is rejected
+  // by spec-conformant WHATWG URL parsers (ada >= 4.0.0: Node.js >= 26, and 24.20+).
+  let hashIndex = switchSchema.indexOf('#');
+  let fragment = (hashIndex === -1 || hashIndex === switchSchema.length - 1) ? '' : switchSchema.substr(hashIndex);
   var document = fragment && fragment.length && switchSchema.substr(0, switchSchema.length - fragment.length);
   if (!document || !ctx.schemas[document]) {
     throw new SchemaError("no such schema <" + switchSchema + ">", schema);

--- a/test/fragment-ref-no-id.js
+++ b/test/fragment-ref-no-id.js
@@ -1,0 +1,20 @@
+'use strict';
+var Validator = require('../lib/validator');
+var assert = require('assert');
+
+describe('$ref to a local fragment on a schema without $id (issue #423)', function () {
+  it('resolves "#/definitions/X" without constructing a URL from an opaque base', function () {
+    var schema = {
+      $ref: '#/definitions/X',
+      definitions: { X: { type: 'object' } },
+    };
+    var result = new Validator().validate({}, schema);
+    assert.strictEqual(result.valid, true);
+    var bad = new Validator().validate(1, schema);
+    assert.strictEqual(bad.valid, false);
+  });
+  it('still reports an unknown document as SchemaError', function () {
+    var schema = { $ref: 'missing.json#/definitions/X' };
+    assert.throws(function () { new Validator().validate({}, schema); }, /no such schema/);
+  });
+});


### PR DESCRIPTION
Fixes #423.

`Validator.prototype.resolve` parses the ref against a throwaway base, `new URL(switchSchema, 'thismessage::/')`, purely to read `.hash` off the result. That base has an *opaque path* (`:/` does not start with `/`), and when `switchSchema` is a bare path such as `/undefined#/definitions/X` (any local-fragment `$ref` on a schema without `$id`) the input has no scheme and does not start with `#` — per the WHATWG "no scheme state" that is a failure. ada < 4 accepted any input *containing* a `#`; ada 4.0.0 fixed that ("fix no scheme state accepting any input containing a fragment"), so on Node.js 26 — and 24.20+, which carries the backport — every such `$ref` throws `TypeError [ERR_INVALID_URL]`.

This PR splits the fragment off by hand instead. Behaviour for every other input is unchanged: an empty fragment (`"a#"`) still falls through to `no such schema`, exactly as `URL.hash === ''` did. (`helpers.resolveUrl` uses `resolve://`, a base *with* an authority, and resolves correctly under ada 4 — left as is.)

Verification on Node.js v26.7.0 with the JSON-Schema-Test-Suite submodule:
- `master` unpatched: 2696 passing, **70 failing** (all `TypeError: Invalid URL`)
- this branch: **2766 passing, 0 failing** (includes the new `test/fragment-ref-no-id.js`, which reproduces #423 and pins the `SchemaError` arm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEqMjUB5ioiYUqFDVYKmnR
